### PR TITLE
Refresh expired token on check

### DIFF
--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -285,6 +285,9 @@ class KindeSDK(
     }
 
     private fun checkToken(): Boolean {
+        if (isTokenExpired(TokenType.ACCESS_TOKEN)) {
+            getToken(state.createTokenRefreshRequest())
+        }
         if (state.isAuthorized) {
             store.getKeys()?.let { keysString ->
                 try {
@@ -331,6 +334,19 @@ class KindeSDK(
             }
         }
         return null
+    }
+
+    private fun isTokenExpired(tokenType: TokenType): Boolean {
+        val expClaim = getClaim("exp", tokenType)
+        if (expClaim.value != null) {
+            val expireEpochMillis = (expClaim.value as Long) * 1000
+            val currentTimeMillis = System.currentTimeMillis()
+
+            if (currentTimeMillis > expireEpochMillis) {
+                return true
+            }
+        }
+        return false
     }
 
     companion object {


### PR DESCRIPTION
# Explain your changes

When application starts and token `exp` claim is out of date it fails with requests to backend. This change introduces token refresh on `checkToken` operation as it is called on each request to the API and during startup

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
