### PR TITLE
fix: Removes duplicate actions when logging out

### DIFF
--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -220,10 +220,6 @@ class KindeSDK(
             .build()
         val endSessionIntent = authService.getEndSessionRequestIntent(endSessionRequest)
         endTokenLauncher.launch(endSessionIntent)
-
-        apiClient.setBearerToken("")
-        sdkListener.onLogout()
-        store.clearState()
     }
 
     fun isAuthenticated() = state.isAuthorized && checkToken()


### PR DESCRIPTION
# Explain your changes

This commit removes the duplicate calls when logging out to fix the issue double logout function.

On `KindeSDK.kt`, when users call `function logout()`, it'll execute `endTokenLauncher` activity. 
In endTokenLauncher, the activity has already called these 3 functions to execute. 
So it's redundant on logout() function to re-call those three functions again.

```bash
private val endTokenLauncher = activity.registerForActivityResult(
        ActivityResultContracts.StartActivityForResult()
    ) { result ->
        val data = result.data
        if (result.resultCode == AppCompatActivity.RESULT_OK && data != null) {
            val resp = EndSessionResponse.fromIntent(data)
            val ex = AuthorizationException.fromIntent(data)
            // these three functions
            apiClient.setBearerToken("")
            sdkListener.onLogout()
            store.clearState()
            //
            ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
        }
    }
```

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
