### PR TITLE
Org name constant bug fix

### DIFF
--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -371,7 +371,7 @@ class KindeSDK(
         private const val REGISTRATION_PAGE_PARAM_VALUE = "registration"
         private const val AUDIENCE_PARAM_NAME = "audience"
         private const val CREATE_ORG_PARAM_NAME = "is_create_org"
-        private const val ORG_NAME_PARAM_NAME = "org_name "
+        private const val ORG_NAME_PARAM_NAME = "org_name"
         private const val ORG_CODE_PARAM_NAME = "org_code"
         private const val REDIRECT_PARAM_NAME = "redirect"
 


### PR DESCRIPTION
# Explain your changes

ORG_NAME_PARAM_NAME constant had an incorrect whitespace added to the String value.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
