### PR TITLE
feat: v2.0.0 — modernize dependencies/toolchain (minSdk 23) and fix audience meta-data key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compile_version = 32
+        compile_version = 36
         sdk_version = "2.0.0"
 
-        kotlin_version = "1.9.25"
+        kotlin_version = "2.1.20"
     }
     repositories {
         google()

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 21
+        minSdk 23
         targetSdk compile_version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -251,7 +251,10 @@ class KindeSDK(
             ?: throw IllegalStateException("$DOMAIN_KEY is not present at meta-data")
         configClientId = metaData.getString(CLIENT_ID_KEY)?.trim()?.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("$CLIENT_ID_KEY is not present at meta-data")
-        audience = metaData.getString(AUDIENCE_KEY)?.trim()?.takeIf { it.isNotBlank() }
+        // Prefer the namespaced key; fall back to the legacy non-namespaced "audience"
+        // key for backwards compatibility with apps configured before the rename.
+        audience = (metaData.getString(AUDIENCE_KEY) ?: metaData.getString(AUDIENCE_KEY_LEGACY))
+            ?.trim()?.takeIf { it.isNotBlank() }
         serviceConfiguration = getServiceConfiguration(configDomain)
 
         store = Store(activity, configDomain)
@@ -1372,7 +1375,8 @@ class KindeSDK(
     companion object {
         private const val DOMAIN_KEY = "au.kinde.domain"
         private const val CLIENT_ID_KEY = "au.kinde.clientId"
-        private const val AUDIENCE_KEY = "audience"
+        private const val AUDIENCE_KEY = "au.kinde.audience"
+        private const val AUDIENCE_KEY_LEGACY = "audience"
 
         private const val AUTH_URL = "https://%s/oauth2/auth"
         private const val TOKEN_URL = "https://%s/oauth2/token"

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -253,8 +253,10 @@ class KindeSDK(
             ?: throw IllegalStateException("$CLIENT_ID_KEY is not present at meta-data")
         // Prefer the namespaced key; fall back to the legacy non-namespaced "audience"
         // key for backwards compatibility with apps configured before the rename.
-        audience = (metaData.getString(AUDIENCE_KEY) ?: metaData.getString(AUDIENCE_KEY_LEGACY))
-            ?.trim()?.takeIf { it.isNotBlank() }
+        // Blank/whitespace-only values are treated as missing so a blank namespaced
+        // key does not shadow a valid legacy value.
+        audience = metaData.getString(AUDIENCE_KEY)?.trim()?.takeIf { it.isNotBlank() }
+            ?: metaData.getString(AUDIENCE_KEY_LEGACY)?.trim()?.takeIf { it.isNotBlank() }
         serviceConfiguration = getServiceConfiguration(configDomain)
 
         store = Store(activity, configDomain)

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -1,5 +1,6 @@
 package au.kinde.sdk
 
+import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.Looper
@@ -75,7 +76,7 @@ class KindeSDK(
     ) { result ->
         val data = result.data
 
-        if (result.resultCode == ComponentActivity.RESULT_CANCELED) {
+        if (result.resultCode == Activity.RESULT_CANCELED) {
             val wasHandlingInvitation = invitationState.isHandling
             invitationState.completeHandling()
 
@@ -98,7 +99,7 @@ class KindeSDK(
             }
         }
 
-        if (result.resultCode == ComponentActivity.RESULT_OK && data != null) {
+        if (result.resultCode == Activity.RESULT_OK && data != null) {
             val resp = AuthorizationResponse.fromIntent(data)
             val ex = AuthorizationException.fromIntent(data)
             synchronized(stateLock) {
@@ -140,7 +141,7 @@ class KindeSDK(
         val data = result.data
 
         when (result.resultCode) {
-            ComponentActivity.RESULT_CANCELED -> {
+            Activity.RESULT_CANCELED -> {
                 data?.let {
                     val ex = AuthorizationException.fromIntent(it)
                     ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
@@ -151,7 +152,7 @@ class KindeSDK(
                 }
                 scheduleTokenRefresh()
             }
-            ComponentActivity.RESULT_OK -> {
+            Activity.RESULT_OK -> {
                 val storeToClean = store
                 clearRuntimeOverrides()
 


### PR DESCRIPTION
## Summary

This branch brings the half-finished Renovate dependency migration currently on `main` as well as the audience meta-data fix. It is split into two focused commits:

- **`build:` modernize toolchain and raise minSdk to 23 for 2.0.0**
  - `compileSdk` 32 → 36, Kotlin 1.9.25 → 2.1.20 (required by `retrofit:2.12.0`'s Kotlin 2.1 metadata and `appcompat:1.7.1`'s compileSdk 34+ requirement)
  - `minSdk` 21 → 23 (required by `androidx.browser:1.10.0`)
  - `ComponentActivity.RESULT_*` → `Activity.RESULT_*` (the constants no longer resolve via `ComponentActivity` on the new toolchain)
- **`fix(audience):` read namespaced `au.kinde.audience` meta-data key with legacy fallback**
  - The [docs](https://docs.kinde.com/developer-tools/sdks/native/android-sdk/#audience) document the key as `au.kinde.audience`, but the SDK previously read the bare `audience` key, so docs-following apps had their requested audience silently ignored.
  - Now reads the namespaced key first and falls back to the legacy `audience` key, so existing integrations keep working (backwards compatible).

## Breaking change (major → 2.0.0)

Raising `minSdk` 21 → 23 drops Android 5.0/5.1 (API 21/22) support. Per current Google distribution data that is ~0.4% of active devices,  all unsupported (Play Services support for Lollipop ended July 2024). `compileSdk 34+` and Kotlin 2.x become build-time requirements for integrators (already the norm given Play's `targetSdk 34+` mandate).

The `fix(audience)` commit is isolated so it can be cherry-picked onto the `v1.6.x` line as a patch if an API 21/22-pinned client ever needs it without the breaking `minSdk` bump. 

## Test plan

- [x] `:sdk:assembleDebug` builds green on the new toolchain
- [x] No linter errors in `KindeSDK.kt`
- [x] Sandbox `refresh-token-app` installs against the v2 `:sdk` and completes an end-to-end PKCE login (token issued, `Status: Authenticated`)
- [x] Verify the `aud` claim on-device against a registered custom API (requires a Kinde-registered API audience)