### PR TITLE
fix: restore AGP 9 build with kotlin-android

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # AGP 9 has built-in Kotlin support; opt out to keep using the kotlin-android plugin
-# TODO: remove these flags and migrate to AGP's built-in Kotlin before upgrading to AGP 10
+# Remove these flags and migrate to AGP's built-in Kotlin before upgrading to AGP 10
 android.builtInKotlin=false
 android.newDsl=false
 # Kotlin code style for this project: "official" or "obsolete":

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # AGP 9 has built-in Kotlin support; opt out to keep using the kotlin-android plugin
-# TODO: remove this flag and migrate to AGP's built-in Kotlin before upgrading to AGP 10
+# TODO: remove these flags and migrate to AGP's built-in Kotlin before upgrading to AGP 10
 android.builtInKotlin=false
+android.newDsl=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Enables namespacing of each library's R class so that its R class includes only the


### PR DESCRIPTION
Adds android.newDsl=false so AGP 9 builds again with the kotlin-android plugin after the incomplete opt-out in #62.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
