### PR TITLE
local auth state cleared after logout

### DIFF
--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -137,51 +137,10 @@ class KindeSDK(
 
     private val endTokenLauncher = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        val data = result.data
-
-        when (result.resultCode) {
-            Activity.RESULT_CANCELED -> {
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-
-                synchronized(stateLock) {
-                    isLoggingOut = false
-                }
-                scheduleTokenRefresh()
-            }
-            Activity.RESULT_OK -> {
-                val storeToClean = store
-                clearRuntimeOverrides()
-
-                synchronized(stateLock) {
-                    apiClient.setBearerToken("")
-                    storeToClean.clearState()
-                    state = AuthState(getServiceConfiguration(configDomain))
-                    isLoggingOut = false
-                }
-
-                sdkListener.onLogout()
-
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-            }
-            else -> {
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-
-                synchronized(stateLock) {
-                    isLoggingOut = false
-                }
-                scheduleTokenRefresh()
-            }
-        }
+    ) { _ ->
+        // Local-first logout: clear the app session whether the browser
+        // end-session completed or the user dismissed/cancelled the Custom Tab.
+        completeLocalLogout()
     }
 
     private val configDomain: String
@@ -388,6 +347,24 @@ class KindeSDK(
             }
             createServices()
         }
+    }
+
+    /**
+     * Clears local auth state after logout is initiated, including when the
+     * browser end-session flow is cancelled or fails unexpectedly.
+     */
+    private fun completeLocalLogout() {
+        val storeToClean = store
+        clearRuntimeOverrides()
+
+        synchronized(stateLock) {
+            apiClient.setBearerToken("")
+            storeToClean.clearState()
+            state = AuthState(getServiceConfiguration(configDomain))
+            isLoggingOut = false
+        }
+
+        sdkListener.onLogout()
     }
 
     override fun getToken(tokenType: TokenType): String? = synchronized(stateLock) {


### PR DESCRIPTION
Clear local auth state and call onLogout() whenever the logout Custom Tab returns, including user cancel/dismiss.
Stop emitting LogoutException / restarting token refresh when the browser end-session flow is cancelled.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
