### PR TITLE
Refactor/decouple sdk from activity lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ android {
 }
 ```
 
+## Accessing tokens without an Activity
+
+Token state, refresh scheduling and API access live in an application-scoped
+core, `KindeClient`, which is shared by every `KindeSDK` instance and survives
+activity recreation. Wherever you need a token and don't have an activity — an
+OkHttp interceptor, a background worker — use the core directly:
+
+```kotlin
+val client = KindeClient.getInstance(context)
+val accessToken = client.getToken(TokenType.ACCESS_TOKEN)
+```
+
+Login, registration and logout open a browser tab, so they still require an
+activity-bound `KindeSDK`, constructed in `onCreate` as shown above. Creating a
+`KindeSDK` in every activity's `onCreate` (including after rotation) remains the
+intended pattern — it is a thin facade, and all of them share the same
+`KindeClient` state underneath.
+
 ## Publishing
 
 The core team handles publishing.

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -17,6 +17,11 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        // Consumed only by this module's own (unit) test manifest merge, which
+        // pulls in AppAuth's manifest. Not published; consuming apps must still
+        // define their own appAuthRedirectScheme.
+        manifestPlaceholders = [appAuthRedirectScheme: 'au.kinde.sdk.tests']
     }
 
     buildTypes {
@@ -32,6 +37,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -41,6 +51,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.9.2'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -39,6 +39,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.lifecycle:lifecycle-process:2.9.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
@@ -1400,6 +1400,15 @@ class KindeClient private constructor(
                     val tokenRequest = try {
                         state.createTokenRefreshRequest()
                     } catch (e: IllegalStateException) {
+                        // Expected when a concurrent logout cleared the state — stop
+                        // quietly. For a live session it means the refresh loop is
+                        // ending (e.g. no refresh token was granted), which the app
+                        // should hear about rather than discovering via an expired
+                        // token.
+                        android.util.Log.w("KindeSDK", "Token refresh stopped: cannot create refresh request", e)
+                        if (isAuthenticated()) {
+                            notifyException(TokenException("Token refresh stopped: ${e.message}"))
+                        }
                         return@thread
                     }
                     val success = getToken(tokenRequest, notifyListener = false)

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
@@ -138,6 +138,17 @@ class KindeClient private constructor(
     @Volatile
     private var isLoggingOut = false
 
+    // When the in-flight logout claimed the flag. The end-session browser result
+    // can be lost (initiating activity destroyed with the tab open), and with a
+    // process-wide client a lost result must not block logout/refresh forever.
+    @Volatile
+    private var logoutStartedAt = 0L
+
+    // How long to wait for the end-session result before treating the logout as
+    // abandoned and allowing recovery.
+    @androidx.annotation.VisibleForTesting
+    internal var logoutResultTimeoutMs = 60_000L
+
     @Volatile
     private var activeBackgroundOperations = 0
 
@@ -313,6 +324,11 @@ class KindeClient private constructor(
      * restored session, or a logout signal when no session exists.
      */
     internal fun notifyInitialState(listener: SDKListener) {
+        // Pre-refactor, a recreated activity started with a fresh instance, which
+        // implicitly recovered from a logout whose browser result was lost. With a
+        // shared client, recover explicitly when a new facade attaches.
+        recoverStaleLogout()
+
         // Pre-refactor, every activity construction re-ran the keys fetch, so a
         // transient failure self-healed on the next screen. Preserve that: retry
         // whenever a facade attaches and keys are still missing.
@@ -514,8 +530,13 @@ class KindeClient private constructor(
         launch: ((Intent) -> Unit)? = null
     ) {
         synchronized(stateLock) {
-            if (isLoggingOut) return
+            if (isLoggingOut) {
+                val stale = System.currentTimeMillis() - logoutStartedAt >= logoutResultTimeoutMs
+                if (!stale) return
+                android.util.Log.w("KindeSDK", "Previous logout never received its end-session result; restarting logout")
+            }
             isLoggingOut = true
+            logoutStartedAt = System.currentTimeMillis()
         }
 
         clearCache()
@@ -553,22 +574,57 @@ class KindeClient private constructor(
                 }
 
                 val fallbackRoute = endSessionRoutes.lastOrNull()
-                when {
-                    // The initiating facade supplied its own launcher: use it with
-                    // its own redirect, exactly like the login flows do.
-                    launch != null && logoutRedirect != null ->
-                        launch(endSessionIntent(logoutRedirect))
-                    // Background-triggered logout: route through any alive facade,
-                    // with the redirect that facade was configured with.
-                    fallbackRoute != null ->
-                        fallbackRoute.launcher.launchEndSession(endSessionIntent(fallbackRoute.logoutRedirect))
-                    // No activity is attached at all, so the end-session browser
-                    // round-trip is impossible. Clear the local session directly.
-                    else -> completeLogoutLocally()
+                val launched = try {
+                    when {
+                        // The initiating facade supplied its own launcher: use it with
+                        // its own redirect, exactly like the login flows do.
+                        launch != null && logoutRedirect != null -> {
+                            launch(endSessionIntent(logoutRedirect))
+                            true
+                        }
+                        // Background-triggered logout: route through any alive facade,
+                        // with the redirect that facade was configured with.
+                        fallbackRoute != null -> {
+                            fallbackRoute.launcher.launchEndSession(endSessionIntent(fallbackRoute.logoutRedirect))
+                            true
+                        }
+                        else -> false
+                    }
+                } catch (e: Exception) {
+                    // Launcher or browser unavailable (activity destroyed mid-logout,
+                    // no browser installed): no result will ever arrive, so don't
+                    // leave the logout pending forever.
+                    android.util.Log.w("KindeSDK", "End-session launch failed; completing logout locally", e)
+                    false
+                }
+                if (!launched) {
+                    // No end-session browser round-trip is possible; clear the
+                    // local session directly.
+                    completeLogoutLocally()
                 }
             }
         }
     }
+
+    private fun recoverStaleLogout() {
+        synchronized(stateLock) {
+            if (isLoggingOut && System.currentTimeMillis() - logoutStartedAt >= logoutResultTimeoutMs) {
+                android.util.Log.w("KindeSDK", "End-session result never arrived; clearing stale logout state")
+                isLoggingOut = false
+            }
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun markLoggingOutForTest(startedAtMs: Long) {
+        synchronized(stateLock) {
+            isLoggingOut = true
+            logoutStartedAt = startedAtMs
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun isLogoutInProgress(): Boolean = synchronized(stateLock) { isLoggingOut }
 
     /** Clears the local session; the terminal step of a successful logout. */
     private fun completeLogoutLocally() {

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
@@ -1,0 +1,1449 @@
+package au.kinde.sdk
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Base64.URL_SAFE
+import android.util.Base64.decode
+import androidx.core.net.toUri
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import au.kinde.sdk.api.ApiOptions
+import au.kinde.sdk.api.FeatureFlagsApi
+import au.kinde.sdk.api.OAuthApi
+import au.kinde.sdk.api.PermissionsApi
+import au.kinde.sdk.api.RolesApi
+import au.kinde.sdk.api.UsersApi
+import au.kinde.sdk.api.model.entitlements.EntitlementResponse
+import au.kinde.sdk.api.model.entitlements.EntitlementsResponse
+import au.kinde.sdk.api.model.CreateUser200Response
+import au.kinde.sdk.api.model.CreateUserRequest
+import au.kinde.sdk.api.model.User
+import au.kinde.sdk.api.model.UserProfile
+import au.kinde.sdk.api.model.UserProfileV2
+import au.kinde.sdk.infrastructure.ApiClient
+import au.kinde.sdk.keys.Keys
+import au.kinde.sdk.keys.KeysApi
+import au.kinde.sdk.model.ClaimData
+import au.kinde.sdk.model.Flag
+import au.kinde.sdk.model.TokenType
+import au.kinde.sdk.store.Store
+import au.kinde.sdk.token.TokenApi
+import au.kinde.sdk.token.TokenRepository
+import au.kinde.sdk.utils.ClaimApi
+import au.kinde.sdk.utils.ClaimDelegate
+import au.kinde.sdk.utils.TokenProvider
+import au.kinde.sdk.utils.callApi
+import com.google.gson.Gson
+import net.openid.appauth.AuthState
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.CodeVerifierUtil
+import net.openid.appauth.EndSessionRequest
+import net.openid.appauth.ResponseTypeValues
+import net.openid.appauth.TokenRequest
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.RSAPublicKeySpec
+import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.concurrent.thread
+
+/**
+ * Application-scoped core of the Kinde SDK.
+ *
+ * Owns everything that must outlive any single activity: the persisted auth state,
+ * the in-memory [AuthState], the token refresh schedule, and the API clients.
+ * There is exactly one instance per process, obtained via [getInstance], so every
+ * [KindeSDK] facade (one per activity) shares the same token state and the same
+ * refresh loop.
+ *
+ * Use this class directly wherever tokens are needed without an activity — for
+ * example an OkHttp interceptor or a background worker:
+ *
+ * ```
+ * val token = KindeClient.getInstance(context).getToken(TokenType.ACCESS_TOKEN)
+ * ```
+ *
+ * Login, registration and logout open a browser tab and therefore still require
+ * an activity-bound [KindeSDK].
+ */
+class KindeClient private constructor(
+    private val appContext: Context
+) : TokenProvider, ClaimApi by ClaimDelegate {
+
+    /**
+     * Bridge to an activity-bound facade capable of launching the end-session
+     * browser tab. Registered by [KindeSDK] while its activity is alive.
+     */
+    internal interface EndSessionLauncher {
+        fun launchEndSession(intent: Intent)
+    }
+
+    private val gson = Gson()
+    private val serviceConfiguration: AuthorizationServiceConfiguration
+
+    @Volatile
+    private lateinit var state: AuthState
+    private val authService = AuthorizationService(appContext)
+
+    internal val configDomain: String
+    private val configClientId: String
+    private val audience: String?
+
+    // Runtime overrides for domain and clientId (cleared on logout)
+    @Volatile
+    private var runtimeDomain: String? = null
+
+    @Volatile
+    private var runtimeClientId: String? = null
+    private var store: Store
+    private lateinit var tokenRepository: TokenRepository
+    private val apiClient: ApiClient
+    private lateinit var keysApi: KeysApi
+    private lateinit var oAuthApi: OAuthApi
+    private lateinit var usersApi: UsersApi
+    private lateinit var permissionsApi: PermissionsApi
+    private lateinit var rolesApi: RolesApi
+    private lateinit var featureFlagsApi: FeatureFlagsApi
+    private val tokenRefreshHandler = Handler(Looper.getMainLooper())
+
+    @Volatile
+    private var tokenRefreshRunnable: Runnable? = null
+
+    @Volatile
+    private var isPaused = false
+    private var lastTokenUpdateTime = 0L
+    private val stateLock = Object()
+    private val refreshLock = Object()
+    private val domainSwitchLock = Object()
+
+    @Volatile
+    private var isRefreshing = false
+
+    @Volatile
+    private var isLoggingOut = false
+
+    @Volatile
+    private var activeBackgroundOperations = 0
+
+    // Listeners from all currently alive facades. Broadcasts must never happen
+    // while a lock is held (see the snapshot-then-notify pattern in getToken).
+    private val listeners = CopyOnWriteArraySet<SDKListener>()
+
+    @Volatile
+    private var endSessionLauncher: EndSessionLauncher? = null
+
+    // Logout redirect supplied by the most recently attached facade, so a
+    // logout triggered from a background failure can still build the
+    // end-session request.
+    @Volatile
+    private var attachedLogoutRedirect: String? = null
+
+    // Centralized invitation state management
+    internal val invitationState = InvitationState()
+
+    // Cache infrastructure for API responses
+    private data class CacheEntry<T>(
+        val data: T,
+        val timestamp: Long
+    )
+
+    @Volatile
+    private var permissionsCache: CacheEntry<ClaimData.Permissions>? = null
+
+    @Volatile
+    private var rolesCache: CacheEntry<ClaimData.Roles>? = null
+
+    @Volatile
+    private var flagsCache: CacheEntry<Map<String, Flag>>? = null
+
+    init {
+        @Suppress("DEPRECATION")
+        val appInfo = appContext.packageManager.getApplicationInfo(
+            appContext.packageName,
+            PackageManager.GET_META_DATA
+        )
+        // Required configuration: fail fast so the SDK is never constructed in an
+        // invalid state. A missing value here is a developer/configuration error,
+        // not a runtime auth error, so it is thrown rather than routed through onException.
+        val metaData = appInfo.metaData
+            ?: throw IllegalStateException("No meta-data found in AndroidManifest; $DOMAIN_KEY and $CLIENT_ID_KEY are required")
+        configDomain = metaData.getString(DOMAIN_KEY)?.trim()?.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("$DOMAIN_KEY is not present at meta-data")
+        configClientId = metaData.getString(CLIENT_ID_KEY)?.trim()?.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("$CLIENT_ID_KEY is not present at meta-data")
+        // Prefer the namespaced key; fall back to the legacy non-namespaced "audience"
+        // key for backwards compatibility with apps configured before the rename.
+        // Blank/whitespace-only values are treated as missing so a blank namespaced
+        // key does not shadow a valid legacy value.
+        audience = metaData.getString(AUDIENCE_KEY)?.trim()?.takeIf { it.isNotBlank() }
+            ?: metaData.getString(AUDIENCE_KEY_LEGACY)?.trim()?.takeIf { it.isNotBlank() }
+        serviceConfiguration = getServiceConfiguration(configDomain)
+
+        store = Store(appContext, configDomain)
+
+        val stateJson = store.getState()
+        state = if (!stateJson.isNullOrEmpty()) {
+            AuthState.jsonDeserialize(stateJson)
+        } else {
+            AuthState(serviceConfiguration)
+        }
+
+        apiClient = ApiClient(HTTPS.format(configDomain), authNames = arrayOf(BEARER_AUTH))
+
+        createServices()
+
+        ClaimDelegate.tokenProvider = this
+
+        initializeStoreData()
+
+        // The refresh schedule follows the whole app's foreground state rather than
+        // any single activity's, so navigation and recreation no longer cancel it.
+        runOnMainThread {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                    isPaused = false
+                    refreshState()
+                    if (isAuthenticated()) {
+                        scheduleTokenRefresh()
+                    }
+                }
+
+                override fun onStop(owner: LifecycleOwner) {
+                    // Cancel scheduled refresh when app goes to background to save battery
+                    isPaused = true
+                    cancelTokenRefresh()
+                }
+            })
+        }
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            tokenRefreshHandler.post(block)
+        }
+    }
+
+    internal fun attachListener(listener: SDKListener) {
+        listeners.add(listener)
+    }
+
+    internal fun detachListener(listener: SDKListener) {
+        listeners.remove(listener)
+    }
+
+    internal fun attachEndSessionLauncher(launcher: EndSessionLauncher, logoutRedirect: String) {
+        endSessionLauncher = launcher
+        attachedLogoutRedirect = logoutRedirect
+    }
+
+    internal fun detachEndSessionLauncher(launcher: EndSessionLauncher) {
+        // Only clear if this facade is still the active one; a newer activity may
+        // have attached its own launcher before the old activity is destroyed.
+        if (endSessionLauncher === launcher) {
+            endSessionLauncher = null
+        }
+    }
+
+    private fun notifyNewToken(token: String) {
+        listeners.forEach { it.onNewToken(token) }
+    }
+
+    private fun notifyLogout() {
+        listeners.forEach { it.onLogout() }
+    }
+
+    private fun notifyException(exception: Exception) {
+        listeners.forEach { it.onException(exception) }
+    }
+
+    /**
+     * Replays the current auth state to a newly attached listener, mirroring the
+     * events a freshly constructed [KindeSDK] has always emitted: a token for a
+     * restored session, or a logout signal when no session exists.
+     */
+    internal fun notifyInitialState(listener: SDKListener) {
+        val stateJson = store.getState()
+        if (!stateJson.isNullOrEmpty()) {
+            if (isAuthenticated()) {
+                val accessToken = synchronized(stateLock) { state.accessToken }
+                accessToken?.let {
+                    apiClient.setBearerToken(it)
+                    listener.onNewToken(it)
+                    scheduleTokenRefresh()
+                }
+            }
+        } else {
+            listener.onLogout()
+        }
+    }
+
+    /**
+     * Validates a domain string to ensure it's a valid hostname
+     * without scheme, path, whitespace, or special characters.
+     *
+     * Enforces RFC 1035 constraints:
+     * - Total length ≤ 255 characters
+     * - Each label (part between dots) ≤ 63 characters
+     * - Labels must start/end with alphanumeric, hyphens only in middle
+     *
+     * @param domain The domain to validate
+     * @return true if valid, false otherwise
+     */
+    private fun isValidDomain(domain: String): Boolean {
+        if (domain.isBlank()) return false
+
+        // Check for invalid characters and patterns
+        if (domain.contains("://") ||  // no scheme
+            domain.contains("/") ||    // no path
+            domain.contains("@") ||     // no credentials
+            domain.contains(" ") ||     // no whitespace
+            domain.contains("\t") ||    // no tabs
+            domain.contains("\n") ||    // no newlines
+            domain.contains("\r")
+        ) {    // no carriage returns
+            return false
+        }
+
+        // RFC 1035 compliant hostname validation with length constraints
+        // - Max 255 chars total
+        // - Each label max 63 chars
+        // - Labels start/end with alphanumeric, hyphens only in middle
+        val hostnameRegex =
+            "^(?!.{256,})[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$".toRegex()
+        return hostnameRegex.matches(domain)
+    }
+
+    /**
+     * Validates a client ID string to ensure it's non-blank
+     * and contains no whitespace or control characters.
+     *
+     * @param clientId The client ID to validate
+     * @return true if valid, false otherwise
+     */
+    private fun isValidClientId(clientId: String): Boolean {
+        if (clientId.isBlank()) return false
+        return clientId.none { it.isWhitespace() || it.isISOControl() }
+    }
+
+    /**
+     * Clears runtime overrides and resets to default configuration if needed
+     */
+    private fun clearRuntimeOverrides() {
+        val hadRuntimeDomain = runtimeDomain != null
+        runtimeDomain = null
+        runtimeClientId = null
+
+        if (hadRuntimeDomain) {
+            // Reset API client to default domain
+            apiClient.setBaseUrl(HTTPS.format(configDomain))
+            store = Store(appContext, configDomain)
+            synchronized(stateLock) {
+                val defaultConfig = getServiceConfiguration(configDomain)
+                state = AuthState(defaultConfig)
+            }
+            createServices()
+        }
+    }
+
+    override fun getToken(tokenType: TokenType): String? = synchronized(stateLock) {
+        if (tokenType == TokenType.ACCESS_TOKEN) state.accessToken else state.idToken
+    }
+
+    fun getRefreshToken(): String? = synchronized(stateLock) { state.refreshToken }
+
+    internal fun login(
+        type: GrantType?,
+        orgCode: String?,
+        loginHint: String?,
+        domain: String?,
+        clientId: String?,
+        invitationCode: String?,
+        connectionId: String?,
+        loginRedirect: String,
+        scopes: List<String>,
+        launch: (Intent) -> Unit
+    ) {
+        if (!invitationCode.isNullOrBlank()) {
+            handleInvitation(invitationCode, type, orgCode, loginRedirect, scopes, launch)
+        } else {
+            val params = mutableMapOf<String, String>()
+            authorize(type, orgCode, loginHint, params, domain, clientId, connectionId, loginRedirect, scopes, launch)
+        }
+    }
+
+    internal fun register(
+        type: GrantType?,
+        orgCode: String?,
+        loginHint: String?,
+        pricingTableKey: String?,
+        planInterest: String?,
+        domain: String?,
+        clientId: String?,
+        invitationCode: String?,
+        connectionId: String?,
+        loginRedirect: String,
+        scopes: List<String>,
+        launch: (Intent) -> Unit
+    ) {
+        val params = mutableMapOf<String, String>(
+            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE
+        )
+        if (!pricingTableKey.isNullOrBlank()) {
+            params[PRICING_TABLE_KEY_PARAM_NAME] = pricingTableKey
+        }
+        if (!planInterest.isNullOrBlank()) {
+            params[PLAN_INTEREST_PARAM_NAME] = planInterest
+        }
+        if (!invitationCode.isNullOrBlank()) {
+            handleInvitation(invitationCode, type, orgCode, loginRedirect, scopes, launch)
+        } else {
+            authorize(type, orgCode, loginHint, params, domain, clientId, connectionId, loginRedirect, scopes, launch)
+        }
+    }
+
+    internal fun createOrg(
+        type: GrantType?,
+        orgName: String,
+        pricingTableKey: String?,
+        planInterest: String?,
+        domain: String?,
+        clientId: String?,
+        connectionId: String?,
+        loginRedirect: String,
+        scopes: List<String>,
+        launch: (Intent) -> Unit
+    ) {
+        require(orgName.isNotBlank()) { "orgName cannot be blank" }
+        val params = mutableMapOf<String, String>(
+            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE,
+            CREATE_ORG_PARAM_NAME to true.toString(),
+            ORG_NAME_PARAM_NAME to orgName
+        )
+        if (!pricingTableKey.isNullOrBlank()) {
+            params[PRICING_TABLE_KEY_PARAM_NAME] = pricingTableKey
+        }
+        if (!planInterest.isNullOrBlank()) {
+            params[PLAN_INTEREST_PARAM_NAME] = planInterest
+        }
+        authorize(type, null, null, params, domain, clientId, connectionId, loginRedirect, scopes, launch)
+    }
+
+    internal fun handleInvitation(
+        invitationCode: String,
+        type: GrantType?,
+        orgCode: String?,
+        loginRedirect: String,
+        scopes: List<String>,
+        launch: (Intent) -> Unit
+    ) {
+        if (invitationState.isProcessed(invitationCode)) {
+            // Already processed this invitation code
+            return
+        }
+
+        invitationState.startHandling(invitationCode)
+
+        val params = mutableMapOf(
+            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE,
+            INVITATION_CODE_PARAM_NAME to invitationCode,
+            IS_INVITATION_PARAM_NAME to "true"
+        )
+        authorize(type, orgCode, null, params, null, null, null, loginRedirect, scopes, launch)
+    }
+
+    internal fun logout(logoutRedirect: String? = null) {
+        synchronized(stateLock) {
+            if (isLoggingOut) return
+            isLoggingOut = true
+        }
+
+        clearCache()
+        invitationState.reset()
+        cancelTokenRefresh()
+
+        val effectiveDomain = runtimeDomain ?: configDomain
+        val logoutServiceConfig = getServiceConfiguration(effectiveDomain)
+        val effectiveRedirect = logoutRedirect ?: attachedLogoutRedirect
+
+        thread {
+            synchronized(stateLock) {
+                val deadline = System.currentTimeMillis() + 5000
+                while (activeBackgroundOperations > 0) {
+                    val remainingMillis = deadline - System.currentTimeMillis()
+                    if (remainingMillis <= 0) {
+                        android.util.Log.w("KindeSDK", "Logout timeout waiting for $activeBackgroundOperations background operations")
+                        break
+                    }
+                    try {
+                        stateLock.wait(remainingMillis)
+                    } catch (ie: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        break
+                    }
+                }
+            }
+            tokenRefreshHandler.post {
+                val launcher = endSessionLauncher
+                if (launcher != null && effectiveRedirect != null) {
+                    val endSessionRequest = EndSessionRequest.Builder(logoutServiceConfig)
+                        .setPostLogoutRedirectUri(effectiveRedirect.toUri())
+                        .setAdditionalParameters(mapOf(REDIRECT_PARAM_NAME to effectiveRedirect))
+                        .setState(null)
+                        .build()
+                    launcher.launchEndSession(authService.getEndSessionRequestIntent(endSessionRequest))
+                } else {
+                    // No activity is attached (e.g. a background refresh failed after the
+                    // UI was destroyed), so the end-session browser round-trip is
+                    // impossible. Clear the local session directly.
+                    completeLogoutLocally()
+                }
+            }
+        }
+    }
+
+    /** Clears the local session; the terminal step of a successful logout. */
+    private fun completeLogoutLocally() {
+        val storeToClean = store
+        clearRuntimeOverrides()
+
+        synchronized(stateLock) {
+            apiClient.setBearerToken("")
+            storeToClean.clearState()
+            state = AuthState(getServiceConfiguration(configDomain))
+            isLoggingOut = false
+        }
+
+        notifyLogout()
+    }
+
+    internal fun onAuthorizationResult(resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_CANCELED) {
+            val wasHandlingInvitation = invitationState.isHandling
+            invitationState.completeHandling()
+
+            if (data != null) {
+                val ex = AuthorizationException.fromIntent(data)
+                ex?.let { notifyException(AuthException("${ex.error} ${ex.errorDescription}")) }
+                clearRuntimeOverrides()
+            }
+
+            refreshState()
+
+            if (wasHandlingInvitation) {
+                return
+            }
+
+            if (isAuthenticated()) {
+                synchronized(stateLock) { state.accessToken }?.let { notifyNewToken(it) }
+            } else {
+                notifyLogout()
+            }
+        }
+
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            val resp = AuthorizationResponse.fromIntent(data)
+            val ex = AuthorizationException.fromIntent(data)
+            synchronized(stateLock) {
+                if (isLoggingOut) return
+                state.update(resp, ex)
+                store.saveState(state.jsonSerializeString())
+            }
+            resp?.let {
+                thread {
+                    synchronized(stateLock) {
+                        if (isLoggingOut) return@thread
+                        activeBackgroundOperations++
+                    }
+                    try {
+                        getToken(resp.createTokenExchangeRequest())
+                    } finally {
+                        synchronized(stateLock) {
+                            activeBackgroundOperations--
+                            stateLock.notifyAll()
+                        }
+                    }
+                }
+            }
+            ex?.let {
+                notifyException(AuthException("${ex.error} ${ex.errorDescription}"))
+                invitationState.completeHandling()
+                refreshState()
+                if (!isAuthenticated()) {
+                    notifyLogout()
+                }
+                clearRuntimeOverrides()
+            }
+        }
+    }
+
+    internal fun onEndSessionResult(resultCode: Int, data: Intent?) {
+        when (resultCode) {
+            Activity.RESULT_CANCELED -> {
+                data?.let {
+                    val ex = AuthorizationException.fromIntent(it)
+                    ex?.let { notifyException(LogoutException("${ex.error} ${ex.errorDescription}")) }
+                }
+
+                synchronized(stateLock) {
+                    isLoggingOut = false
+                }
+                scheduleTokenRefresh()
+            }
+            Activity.RESULT_OK -> {
+                completeLogoutLocally()
+
+                data?.let {
+                    val ex = AuthorizationException.fromIntent(it)
+                    ex?.let { notifyException(LogoutException("${ex.error} ${ex.errorDescription}")) }
+                }
+            }
+            else -> {
+                data?.let {
+                    val ex = AuthorizationException.fromIntent(it)
+                    ex?.let { notifyException(LogoutException("${ex.error} ${ex.errorDescription}")) }
+                }
+
+                synchronized(stateLock) {
+                    isLoggingOut = false
+                }
+                scheduleTokenRefresh()
+            }
+        }
+    }
+
+    /**
+     * Refreshes the authentication state from persistent storage.
+     * Call this method when you need to sync the in-memory state with storage.
+     */
+    fun refreshState() {
+        synchronized(stateLock) {
+            val stateJson = store.getState()
+            if (!stateJson.isNullOrBlank()) {
+                state = AuthState.jsonDeserialize(stateJson)
+            }
+        }
+    }
+
+    /**
+     * Checks if the user is currently authenticated.
+     * This method relies on shared preferences rather than in-memory state.
+     */
+    fun isAuthenticated(): Boolean {
+        synchronized(stateLock) {
+            val stateJson = store.getState()
+            if (stateJson.isNullOrBlank()) return false
+            // Temporarily deserialize to check auth status without mutating instance state
+            val currentState = AuthState.jsonDeserialize(stateJson)
+            return currentState.isAuthorized && checkTokenWithState(currentState)
+        }
+    }
+
+    /**
+     * Clears all cached API responses (permissions, roles, and feature flags).
+     * Call this when you need to force fresh data on the next API call, or when switching contexts
+     * (e.g., changing organizations).
+     */
+    fun clearCache() {
+        permissionsCache = null
+        rolesCache = null
+        flagsCache = null
+    }
+
+    /**
+     * Check if the SDK is currently handling an invitation code.
+     * This can be used to show appropriate loading UI while the invitation flow is in progress.
+     *
+     * @return true if an invitation code was detected and is being processed
+     */
+    fun isHandlingInvitation() = invitationState.isHandling
+
+    fun getUser(): UserProfile? = callApi(oAuthApi.getUser())
+
+    fun getUserProfileV2(): UserProfileV2? = callApi(oAuthApi.getUserProfileV2())
+
+    fun getEntitlement(key: String): EntitlementResponse? = callApi(oAuthApi.getEntitlement(key))
+
+    fun getEntitlements(): EntitlementsResponse? = callApi(oAuthApi.getEntitlements())
+
+    fun createUser(createUserRequest: CreateUserRequest? = null): CreateUser200Response? =
+        callApi(usersApi.createUser(createUserRequest))
+
+    fun getUsers(
+        sort: kotlin.String? = null,
+        pageSize: kotlin.Int? = null,
+        userId: kotlin.Int? = null,
+        nextToken: kotlin.String? = null
+    ): kotlin.collections.List<User>? =
+        callApi(usersApi.getUsers(sort, pageSize, userId, nextToken))
+
+    /**
+     * Get all permissions for the authenticated user
+     *
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API.
+     *                Set useCache = false to bypass cache and force a fresh API call.
+     * @return ClaimData.Permissions containing org code and list of permission keys
+     */
+    // Permissions with forceApi support
+    fun getPermissions(options: ApiOptions? = null): ClaimData.Permissions {
+        return if (options?.forceApi == true) {
+            // Check cache first if caching is enabled
+            if (options.useCache) {
+                val cached = permissionsCache
+                if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
+                    return cached.data
+                }
+            }
+
+            // Fetch from API
+            val response = callApi(permissionsApi.getPermissions())
+                ?: throw Exception("Failed to fetch permissions from API - check network and authentication")
+            if (!response.success) {
+                throw Exception("Permissions API returned success: false")
+            }
+
+            val permissions = ClaimData.Permissions(
+                orgCode = response.data?.orgCode ?: "",
+                permissions = response.getPermissionKeys()
+            )
+
+            // Cache the result if caching is enabled
+            if (options.useCache) {
+                permissionsCache = CacheEntry(permissions, System.currentTimeMillis())
+            }
+
+            permissions
+        } else {
+            ClaimDelegate.getPermissions()
+        }
+    }
+
+    /**
+     * Check if user has a specific permission
+     *
+     * Note: When using forceApi=true, this fetches ALL permissions from the API, but results are
+     * cached for 60 seconds by default. Subsequent calls within the cache window will use cached data.
+     * To force a fresh API call, use ApiOptions(forceApi = true, useCache = false).
+     *
+     * @param permission The permission key to check
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
+     * @return ClaimData.Permission with orgCode and isGranted status
+     */
+    fun getPermission(permission: String, options: ApiOptions? = null): ClaimData.Permission {
+        return if (options?.forceApi == true) {
+            val perms = getPermissions(options)
+            ClaimData.Permission(
+                orgCode = perms.orgCode,
+                isGranted = perms.permissions.contains(permission)
+            )
+        } else {
+            ClaimDelegate.getPermission(permission)
+        }
+    }
+
+    /**
+     * Get all roles for the authenticated user
+     *
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API.
+     *                Set useCache = false to bypass cache and force a fresh API call.
+     * @return ClaimData.Roles containing org code and list of role keys
+     */
+    // Roles with forceApi support
+    fun getRoles(options: ApiOptions? = null): ClaimData.Roles {
+        return if (options?.forceApi == true) {
+            // Check cache first if caching is enabled
+            if (options.useCache) {
+                val cached = rolesCache
+                if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
+                    return cached.data
+                }
+            }
+
+            // Fetch from API
+            val response = callApi(rolesApi.getRoles())
+                ?: throw Exception("Failed to fetch roles from API - check network and authentication")
+            if (!response.success) {
+                throw Exception("Roles API returned success: false")
+            }
+
+            val roles = ClaimData.Roles(
+                orgCode = response.data?.orgCode ?: "",
+                roles = response.getRoleKeys()
+            )
+
+            // Cache the result if caching is enabled
+            if (options.useCache) {
+                rolesCache = CacheEntry(roles, System.currentTimeMillis())
+            }
+
+            roles
+        } else {
+            ClaimDelegate.getRoles()
+        }
+    }
+
+    /**
+     * Check if user has a specific role
+     *
+     * Note: When using forceApi=true, this fetches ALL roles from the API, but results are
+     * cached for 60 seconds by default. Subsequent calls within the cache window will use cached data.
+     * To force a fresh API call, use ApiOptions(forceApi = true, useCache = false).
+     *
+     * @param role The role key to check
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
+     * @return ClaimData.Role with orgCode and isGranted status
+     */
+    fun getRole(role: String, options: ApiOptions? = null): ClaimData.Role {
+        return if (options?.forceApi == true) {
+            val roles = getRoles(options)
+            ClaimData.Role(
+                orgCode = roles.orgCode,
+                isGranted = roles.roles.contains(role)
+            )
+        } else {
+            ClaimDelegate.getRole(role)
+        }
+    }
+
+    /**
+     * Get a boolean feature flag value
+     *
+     * Note: When using forceApi=true, this fetches ALL feature flags from the API, but results are
+     * cached for 60 seconds by default. Subsequent calls within the cache window will use cached data.
+     * To force a fresh API call, use ApiOptions(forceApi = true, useCache = false).
+     *
+     * @param code The flag code/key
+     * @param defaultValue Default value if flag doesn't exist
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
+     * @return The boolean flag value or defaultValue if not found
+     */
+    // Feature flags with forceApi support
+    fun getBooleanFlag(code: String, defaultValue: Boolean? = null, options: ApiOptions? = null): Boolean? {
+        return if (options?.forceApi == true) {
+            val flags = fetchFlagsWithCache(options)
+            val flag = flags[code]
+            when {
+                flag == null -> defaultValue
+                flag.value is Boolean -> flag.value
+                else -> {
+                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected Boolean, got ${flag.type}")
+                    defaultValue
+                }
+            }
+        } else {
+            ClaimDelegate.getBooleanFlag(code, defaultValue)
+        }
+    }
+
+    /**
+     * Get a string feature flag value
+     *
+     * Note: When using forceApi=true, this fetches ALL feature flags from the API, but results are
+     * cached for 60 seconds by default. Subsequent calls within the cache window will use cached data.
+     * To force a fresh API call, use ApiOptions(forceApi = true, useCache = false).
+     *
+     * @param code The flag code/key
+     * @param defaultValue Default value if flag doesn't exist
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
+     * @return The string flag value or defaultValue if not found
+     */
+    fun getStringFlag(code: String, defaultValue: String? = null, options: ApiOptions? = null): String? {
+        return if (options?.forceApi == true) {
+            val flags = fetchFlagsWithCache(options)
+            val flag = flags[code]
+            when {
+                flag == null -> defaultValue
+                flag.value is String -> flag.value
+                else -> {
+                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected String, got ${flag.type}")
+                    defaultValue
+                }
+            }
+        } else {
+            ClaimDelegate.getStringFlag(code, defaultValue)
+        }
+    }
+
+    /**
+     * Get an integer feature flag value
+     *
+     * Note: When using forceApi=true, this fetches ALL feature flags from the API, but results are
+     * cached for 60 seconds by default. Subsequent calls within the cache window will use cached data.
+     * To force a fresh API call, use ApiOptions(forceApi = true, useCache = false).
+     *
+     * @param code The flag code/key
+     * @param defaultValue Default value if flag doesn't exist
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
+     * @return The integer flag value or defaultValue if not found
+     */
+    fun getIntegerFlag(code: String, defaultValue: Int? = null, options: ApiOptions? = null): Int? {
+        return if (options?.forceApi == true) {
+            val flags = fetchFlagsWithCache(options)
+            val flag = flags[code]
+            when {
+                flag == null -> defaultValue
+                flag.value is Number -> flag.value.toInt()
+                else -> {
+                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected Integer, got ${flag.type}")
+                    defaultValue
+                }
+            }
+        } else {
+            ClaimDelegate.getIntegerFlag(code, defaultValue)
+        }
+    }
+
+    /**
+     * Get all feature flags for the authenticated user
+     *
+     * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API.
+     *                Set useCache = false to bypass cache and force a fresh API call.
+     * @return Map of flag codes to Flag objects
+     */
+    fun getAllFlags(options: ApiOptions? = null): Map<String, Flag> {
+        return if (options?.forceApi == true) {
+            fetchFlagsWithCache(options)
+        } else {
+            ClaimDelegate.getAllFlags()
+        }
+    }
+
+    /**
+     * Helper method to fetch feature flags from API with caching support
+     */
+    private fun fetchFlagsWithCache(options: ApiOptions): Map<String, Flag> {
+        // Check cache first if caching is enabled
+        if (options.useCache) {
+            val cached = flagsCache
+            if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
+                return cached.data
+            }
+        }
+
+        // Fetch from API
+        val response = callApi(featureFlagsApi.getFeatureFlags())
+            ?: throw Exception("Failed to fetch feature flags from API - check network and authentication")
+        if (!response.success) {
+            throw Exception("Feature flags API returned success: false")
+        }
+
+        val flags = response.toFlagMap()
+
+        // Cache the result if caching is enabled
+        if (options.useCache) {
+            flagsCache = CacheEntry(flags, System.currentTimeMillis())
+        }
+
+        return flags
+    }
+
+    private fun authorize(
+        type: GrantType?,
+        orgCode: String?,
+        loginHint: String?,
+        additionalParams: Map<String, String>,
+        customDomain: String?,
+        customClientId: String?,
+        connectionId: String?,
+        loginRedirect: String,
+        scopes: List<String>,
+        launch: (Intent) -> Unit
+    ) {
+        // Validate and store runtime overrides if provided
+        customDomain?.let {
+            if (!isValidDomain(it)) {
+                notifyException(
+                    IllegalArgumentException(
+                        "Invalid domain: '$it'. Domain must be a valid hostname without scheme, path, or special characters."
+                    )
+                )
+                return
+            }
+            runtimeDomain = it
+        }
+        customClientId?.let {
+            if (!isValidClientId(it)) {
+                notifyException(
+                    IllegalArgumentException(
+                        "Invalid client ID: '$it'. Client ID must be non-blank and contain no whitespace or control characters."
+                    )
+                )
+                return
+            }
+            runtimeClientId = it
+        }
+
+        // Use runtime values if set, otherwise fall back to config
+        val effectiveDomain = runtimeDomain ?: configDomain
+        val effectiveClientId = runtimeClientId ?: configClientId
+
+        // Reconfigure API client if domain changed
+        reconfigureApiClientIfNeeded(effectiveDomain)
+
+        // Create service configuration with effective domain
+        val loginServiceConfig = getServiceConfiguration(effectiveDomain)
+
+        val verifier =
+            if (type == GrantType.PKCE) CodeVerifierUtil.generateRandomCodeVerifier() else null
+        val authRequestBuilder = AuthorizationRequest.Builder(
+            loginServiceConfig, // the authorization service configuration
+            effectiveClientId, // the client ID (config or runtime override)
+            ResponseTypeValues.CODE, // the response_type value: we want a code
+            loginRedirect.toUri()
+        )
+            .setCodeVerifier(verifier)
+            .setAdditionalParameters(
+                buildMap {
+                    putAll(additionalParams)
+                    audience?.let {
+                        put(AUDIENCE_PARAM_NAME, audience)
+                    }
+                    orgCode?.let {
+                        put(ORG_CODE_PARAM_NAME, orgCode)
+                    }
+                    connectionId?.let {
+                        put(CONNECTION_ID_PARAM_NAME, connectionId)
+                    }
+                }
+            )
+
+        // Extract and set login_hint if it's provided in additionalParams and is not empty.
+        loginHint?.takeIf { it.isNotEmpty() }?.let {
+            authRequestBuilder.setLoginHint(it)
+        }
+
+        val authRequest = authRequestBuilder
+            .setNonce(null)
+            .setScopes(scopes)
+            .build()
+        launch(authService.getAuthorizationRequestIntent(authRequest))
+    }
+
+    private fun getToken(tokenRequest: TokenRequest, notifyListener: Boolean = true): Boolean {
+        // Check if logout is in progress
+        synchronized(stateLock) {
+            if (isLoggingOut) return false
+        }
+
+        val grantType = tokenRequest.grantType
+
+        // For refresh token requests, use synchronized block to prevent concurrent refreshes
+        if (grantType == "refresh_token") {
+            synchronized(refreshLock) {
+                while (isRefreshing) {
+                    try {
+                        refreshLock.wait()
+                    } catch (ie: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        return false
+                    }
+                }
+                // Double-check logout flag after waiting
+                synchronized(stateLock) {
+                    if (isLoggingOut) return false
+                }
+                isRefreshing = true
+            }
+        }
+
+        val (resp, ex) = tokenRepository.getToken(
+            authState = state,
+            tokenRequest = tokenRequest
+        )
+
+        if (resp != null) {
+            // Check logout flag first, then clear isRefreshing if needed (avoid nested locks)
+            val wasLoggingOut = synchronized(stateLock) { isLoggingOut }
+            if (wasLoggingOut) {
+                if (grantType == "refresh_token") {
+                    synchronized(refreshLock) {
+                        isRefreshing = false
+                        refreshLock.notifyAll()
+                    }
+                }
+                return false
+            }
+
+            var shouldNotify = false
+            var snapshotToken = ""
+            synchronized(stateLock) {
+                if (!isLoggingOut) {
+                    state.update(resp, ex)
+                    apiClient.setBearerToken(state.accessToken.orEmpty())
+                    store.saveState(state.jsonSerializeString())
+                    lastTokenUpdateTime = System.currentTimeMillis()
+
+                    if (notifyListener && !state.accessToken.isNullOrEmpty()) {
+                        shouldNotify = true
+                        snapshotToken = state.accessToken.orEmpty()
+                    }
+                }
+            }
+            if (shouldNotify) {
+                notifyNewToken(snapshotToken)
+            }
+
+            if (grantType != "refresh_token") {
+                // Reset invitation handling flag after successful interactive authentication
+                invitationState.completeHandling()
+            }
+
+            if (grantType == "refresh_token") {
+                synchronized(refreshLock) {
+                    // Clear isRefreshing outside of stateLock to avoid nested lock
+                    isRefreshing = false
+                    refreshLock.notifyAll()
+                }
+            }
+
+            // Check if logout happened during state update
+            val logoutHappened = synchronized(stateLock) { isLoggingOut }
+            if (logoutHappened) {
+                return false
+            }
+
+            scheduleTokenRefresh()
+        } else {
+            // Check if this is a 401/invalid_grant error (invalid refresh token)
+            val isInvalidRefreshToken = ex?.let { exception ->
+                val is401 = exception.message?.contains("401") == true
+                val isInvalidGrant = exception.error == "invalid_grant"
+                is401 || isInvalidGrant
+            } ?: false
+
+            ex?.let { notifyException(TokenException("${ex.error} ${ex.errorDescription}")) }
+
+            // Always logout on invalid refresh token (401/invalid_grant)
+            // For other errors, only logout if notifyListener is true (manual refresh)
+            try {
+                if (isInvalidRefreshToken || notifyListener) {
+                    logout()
+                }
+            } finally {
+                if (grantType == "refresh_token") {
+                    synchronized(refreshLock) {
+                        isRefreshing = false
+                        refreshLock.notifyAll()
+                    }
+                }
+            }
+        }
+        return resp != null
+    }
+
+    /*
+    * checkToken should only verify token signature, not trigger refresh
+    * Token refresh is handled automatically by scheduleTokenRefresh()
+    */
+    private fun checkToken() = checkTokenWithState(state)
+
+    private fun checkTokenWithState(authState: AuthState): Boolean {
+        if (authState.isAuthorized) {
+            store.getKeys()?.let { keysString ->
+                try {
+                    gson.fromJson(keysString, Keys::class.java)?.let { keys ->
+                        keys.keys.firstOrNull()?.let { key ->
+                            val jwt = authState.accessToken.orEmpty()
+
+                            val exponentB: ByteArray = decode(key.exponent, URL_SAFE)
+                            val modulusB: ByteArray = decode(key.modulus, URL_SAFE)
+                            val bigExponent = BigInteger(1, exponentB)
+                            val bigModulus = BigInteger(1, modulusB)
+                            val publicKey = KeyFactory.getInstance(key.keyType)
+                                .generatePublic(RSAPublicKeySpec(bigModulus, bigExponent))
+                            val signedData: String = jwt.substring(0, jwt.lastIndexOf("."))
+                            val signatureB64u: String =
+                                jwt.substring(jwt.lastIndexOf(".") + 1, jwt.length)
+                            val signature: ByteArray = decode(signatureB64u, URL_SAFE)
+                            val sig: Signature = Signature.getInstance("SHA256withRSA")
+                            sig.initVerify(publicKey)
+                            sig.update(signedData.toByteArray())
+                            return sig.verify(signature)
+                        }
+                    }
+                } catch (ex: Exception) {
+                    notifyException(ex)
+                }
+            }
+        }
+        return false
+    }
+
+    private fun <T> callApi(call: Call<T>, refreshed: Boolean = false): T? {
+        val (data, exception) = call.callApi(state, refreshed = refreshed)
+        if (data != null) {
+            return data
+        }
+        if (exception != null) {
+            if (exception is TokenExpiredException) {
+                // Use notifyListener=false to prevent logout on API call token refresh
+                if (getToken(state.createTokenRefreshRequest(), notifyListener = false)) {
+                    return callApi(call.clone(), refreshed = true)
+                }
+            } else {
+                notifyException(exception)
+            }
+        }
+        return null
+    }
+
+    private fun getExpireEpochSeconds(tokenType: TokenType): Long? {
+        val expClaim = getClaim("exp", tokenType)
+        return when (val value = expClaim.value) {
+            is Long -> value
+            is String -> value.toLongOrNull()
+            is Number -> value.toLong()
+            else -> null
+        }
+    }
+
+    internal fun scheduleTokenRefresh() {
+        cancelTokenRefresh()
+
+        if (isPaused) {
+            return
+        }
+
+        val expireEpochSeconds = getExpireEpochSeconds(TokenType.ACCESS_TOKEN) ?: return
+
+        val expireEpochMillis = expireEpochSeconds * 1000
+        val refreshTimeMillis = expireEpochMillis - TOKEN_REFRESH_BUFFER_MS
+        val currentTimeMillis = System.currentTimeMillis()
+        val delayMillis = refreshTimeMillis - currentTimeMillis
+
+        val retryDelayMs = 10_000L
+
+        if (delayMillis > 0) {
+            postTokenRefresh(delayMillis, retryDelayMs)
+        } else {
+            // Already inside the buffer window — refresh right away
+            postTokenRefresh(0L, retryDelayMs)
+        }
+    }
+
+    private fun postTokenRefresh(delayMillis: Long, retryDelayMs: Long) {
+        tokenRefreshRunnable = createTokenRefreshRunnable(retryDelayMs)
+        tokenRefreshHandler.postDelayed(tokenRefreshRunnable!!, delayMillis)
+    }
+
+    private fun createTokenRefreshRunnable(retryDelayMs: Long = 10_000L): Runnable {
+        return Runnable {
+            thread {
+                synchronized(stateLock) {
+                    if (isLoggingOut) return@thread
+                    activeBackgroundOperations++
+                }
+                try {
+                    val tokenRequest = try {
+                        state.createTokenRefreshRequest()
+                    } catch (e: IllegalStateException) {
+                        return@thread
+                    }
+                    val success = getToken(tokenRequest, notifyListener = false)
+                    if (!success && !isLoggingOut) {
+                        postTokenRefresh(retryDelayMs, retryDelayMs)
+                    }
+                } finally {
+                    synchronized(stateLock) {
+                        activeBackgroundOperations--
+                        stateLock.notifyAll()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun cancelTokenRefresh() {
+        tokenRefreshRunnable?.let { tokenRefreshHandler.removeCallbacks(it) }
+        tokenRefreshRunnable = null
+    }
+
+    /**
+     * Reconfigures the API clients if the domain has changed from the originally configured domain.
+     * This ensures API calls go to the correct endpoint when using runtime domain overrides.
+     */
+    private fun reconfigureApiClientIfNeeded(effectiveDomain: String) {
+        synchronized(domainSwitchLock) {
+            val currentBaseUrl = apiClient.getBaseUrl()
+            val expectedBaseUrl = HTTPS.format(effectiveDomain)
+
+            if (currentBaseUrl != expectedBaseUrl) {
+                // Clear cached data from the previous domain to prevent stale data issues
+                clearCache()
+
+                // Cancel any scheduled token refresh to prevent sending old tokens to new domain
+                cancelTokenRefresh()
+
+                // Clear bearer token before switching domain to prevent token leakage
+                apiClient.setBearerToken("")
+
+                apiClient.setBaseUrl(expectedBaseUrl)
+
+                // Recreate Store with new domain for domain-specific SharedPreferences
+                store = Store(appContext, effectiveDomain)
+
+                // Update the state's serviceConfiguration to use the new domain
+                val newServiceConfig = getServiceConfiguration(effectiveDomain)
+                synchronized(stateLock) {
+                    // Load any existing state from new domain's store
+                    val stateJson = store.getState()
+                    if (!stateJson.isNullOrEmpty()) {
+                        state = AuthState.jsonDeserialize(stateJson)
+                    } else {
+                        // Create new state with the new service configuration
+                        // This will be used for the token exchange after login
+                        state = AuthState(newServiceConfig)
+                    }
+                }
+
+                createServices()
+
+                // Initialize data for the new domain-specific store
+                initializeStoreData()
+            }
+        }
+    }
+
+    private fun createServices() {
+        // Recreate all service instances to use the updated Retrofit client
+        tokenRepository = TokenRepository(apiClient.createService(TokenApi::class.java), BuildConfig.SDK_VERSION)
+        keysApi = apiClient.createService(KeysApi::class.java)
+        oAuthApi = apiClient.createService(OAuthApi::class.java)
+        usersApi = apiClient.createService(UsersApi::class.java)
+        permissionsApi = apiClient.createService(PermissionsApi::class.java)
+        rolesApi = apiClient.createService(RolesApi::class.java)
+        featureFlagsApi = apiClient.createService(FeatureFlagsApi::class.java)
+    }
+
+    private fun getServiceConfiguration(effectiveDomain: String): AuthorizationServiceConfiguration {
+        return AuthorizationServiceConfiguration(
+            AUTH_URL.format(effectiveDomain).toUri(),
+            TOKEN_URL.format(effectiveDomain).toUri(),
+            null,
+            LOGOUT_URL.format(effectiveDomain).toUri()
+        )
+    }
+
+    /**
+     * Initializes domain-specific data including keys and authentication state.
+     * This should be called when setting up the SDK or when switching domains.
+     */
+    private fun initializeStoreData() {
+        // Capture store reference to prevent race condition if domain switches during async request
+        val storeForRequest = store
+
+        // Fetch and store keys for the domain if not already present
+        if (storeForRequest.getKeys().isNullOrEmpty()) {
+            keysApi.getKeys().enqueue(object : Callback<Keys> {
+                override fun onResponse(call: Call<Keys>, response: Response<Keys>) {
+                    response.body()?.let { keys ->
+                        // Use captured store reference to ensure keys are saved to correct store
+                        storeForRequest.saveKeys(gson.toJson(keys))
+                        // Only set up auth state if this store is still the current one
+                        if (store == storeForRequest) {
+                            setupAuthState()
+                        }
+                    }
+                }
+
+                override fun onFailure(call: Call<Keys>, t: Throwable) {
+                    notifyException(Exception(t))
+                    // Don't proceed with auth setup if keys fetch failed
+                }
+            })
+        } else {
+            // Keys already exist, set up auth state immediately
+            // Only set up if store hasn't changed
+            if (store == storeForRequest) {
+                setupAuthState()
+            }
+        }
+    }
+
+    /**
+     * Sets up authentication state after keys are confirmed to be available.
+     * This ensures signature verification can succeed.
+     */
+    private fun setupAuthState() {
+        // Load and setup authentication state from domain-specific store
+        val stateJson = store.getState()
+        if (!stateJson.isNullOrEmpty()) {
+            refreshState()
+            if (isAuthenticated()) {
+                val accessToken = synchronized(stateLock) { state.accessToken }
+                accessToken?.let {
+                    apiClient.setBearerToken(it)
+                    notifyNewToken(it)
+                    scheduleTokenRefresh()
+                }
+            }
+        }
+        // Note: We don't call onLogout() when state is missing because
+        // missing state doesn't mean the user logged out - it could be
+        // first-time initialization or a domain switch during login.
+        // onLogout() is only called in the actual logout flow.
+    }
+
+    companion object {
+        @Volatile
+        private var instance: KindeClient? = null
+
+        /**
+         * Returns the process-wide [KindeClient], creating it on first use.
+         * Only the application context is retained, so any context is safe to pass.
+         */
+        @JvmStatic
+        fun getInstance(context: Context): KindeClient =
+            instance ?: synchronized(this) {
+                instance ?: KindeClient(context.applicationContext).also { instance = it }
+            }
+
+        /** Test-only: drops the singleton so each test starts from a clean state. */
+        @androidx.annotation.VisibleForTesting
+        internal fun resetInstance() {
+            instance = null
+        }
+
+        private const val DOMAIN_KEY = "au.kinde.domain"
+        private const val CLIENT_ID_KEY = "au.kinde.clientId"
+        private const val AUDIENCE_KEY = "au.kinde.audience"
+        private const val AUDIENCE_KEY_LEGACY = "audience"
+
+        private const val AUTH_URL = "https://%s/oauth2/auth"
+        private const val TOKEN_URL = "https://%s/oauth2/token"
+        private const val LOGOUT_URL = "https://%s/logout"
+
+        private const val REGISTRATION_PAGE_PARAM_NAME = "start_page"
+        private const val REGISTRATION_PAGE_PARAM_VALUE = "registration"
+        private const val AUDIENCE_PARAM_NAME = "audience"
+        private const val CREATE_ORG_PARAM_NAME = "is_create_org"
+        private const val ORG_NAME_PARAM_NAME = "org_name"
+        private const val ORG_CODE_PARAM_NAME = "org_code"
+        private const val PRICING_TABLE_KEY_PARAM_NAME = "pricing_table_key"
+        private const val PLAN_INTEREST_PARAM_NAME = "plan_interest"
+        private const val CONNECTION_ID_PARAM_NAME = "connection_id"
+        private const val REDIRECT_PARAM_NAME = "redirect"
+        internal const val INVITATION_CODE_PARAM_NAME = "invitation_code"
+        private const val IS_INVITATION_PARAM_NAME = "is_invitation"
+
+        private const val HTTPS = "https://%s/"
+        private const val BEARER_AUTH = "kindeBearerAuth"
+
+        // Cache configuration
+        private const val CACHE_TTL_MS = 60_000L // 60 seconds
+        private const val TOKEN_REFRESH_BUFFER_MS = 10_000L // 10 seconds
+    }
+}

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
@@ -606,6 +606,15 @@ class KindeClient private constructor(
         }
     }
 
+    @androidx.annotation.VisibleForTesting
+    internal fun shouldSkipStaleRefresh(
+        requestRefreshToken: String?,
+        currentRefreshToken: String?
+    ): Boolean =
+        requestRefreshToken != null &&
+            currentRefreshToken != null &&
+            requestRefreshToken != currentRefreshToken
+
     private fun recoverStaleLogout() {
         synchronized(stateLock) {
             if (isLoggingOut && System.currentTimeMillis() - logoutStartedAt >= logoutResultTimeoutMs) {
@@ -1184,6 +1193,19 @@ class KindeClient private constructor(
                     if (isLoggingOut) return false
                 }
                 isRefreshing = true
+            }
+
+            // The request was built before any wait above. If another refresh
+            // completed in the meantime and rotated the refresh token, replaying
+            // the old token would be treated as reuse and could revoke the whole
+            // session — the state is already fresh, so report success instead.
+            val currentRefreshToken = synchronized(stateLock) { state.refreshToken }
+            if (shouldSkipStaleRefresh(tokenRequest.refreshToken, currentRefreshToken)) {
+                synchronized(refreshLock) {
+                    isRefreshing = false
+                    refreshLock.notifyAll()
+                }
+                return true
             }
         }
 

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeClient.kt
@@ -10,6 +10,7 @@ import android.util.Base64.URL_SAFE
 import android.util.Base64.decode
 import androidx.core.net.toUri
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.kinde.sdk.api.ApiOptions
@@ -56,7 +57,7 @@ import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.Signature
 import java.security.spec.RSAPublicKeySpec
-import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.concurrent.thread
 
 /**
@@ -95,7 +96,10 @@ class KindeClient private constructor(
 
     @Volatile
     private lateinit var state: AuthState
-    private val authService = AuthorizationService(appContext)
+
+    // Created lazily: consumers that only read tokens (interceptors, workers)
+    // never need the browser service binding this creates.
+    private val authService by lazy { AuthorizationService(appContext) }
 
     internal val configDomain: String
     private val configClientId: String
@@ -137,18 +141,23 @@ class KindeClient private constructor(
     @Volatile
     private var activeBackgroundOperations = 0
 
-    // Listeners from all currently alive facades. Broadcasts must never happen
-    // while a lock is held (see the snapshot-then-notify pattern in getToken).
-    private val listeners = CopyOnWriteArraySet<SDKListener>()
+    // Listeners from all currently alive facades. A list (not a set) so two
+    // facades sharing one listener instance count as two attachments and the
+    // first facade's destroy cannot silence the second; broadcasts dedupe by
+    // instance. Broadcasts must never happen while a lock is held (see the
+    // snapshot-then-notify pattern in getToken).
+    private val listeners = CopyOnWriteArrayList<SDKListener>()
 
-    @Volatile
-    private var endSessionLauncher: EndSessionLauncher? = null
+    // Every alive facade's end-session launcher with its paired logout
+    // redirect. Background-triggered logouts fall back to the most recently
+    // attached route, so back-navigation destroying a newer activity does not
+    // strand logout without a browser launcher.
+    private data class EndSessionRoute(
+        val launcher: EndSessionLauncher,
+        val logoutRedirect: String
+    )
 
-    // Logout redirect supplied by the most recently attached facade, so a
-    // logout triggered from a background failure can still build the
-    // end-session request.
-    @Volatile
-    private var attachedLogoutRedirect: String? = null
+    private val endSessionRoutes = CopyOnWriteArrayList<EndSessionRoute>()
 
     // Centralized invitation state management
     internal val invitationState = InvitationState()
@@ -211,6 +220,11 @@ class KindeClient private constructor(
         // The refresh schedule follows the whole app's foreground state rather than
         // any single activity's, so navigation and recreation no longer cancel it.
         runOnMainThread {
+            // Seed from the current state: if the client is first created while the
+            // process is already backgrounded (worker, interceptor), no onStop will
+            // fire to pause the schedule.
+            isPaused = !ProcessLifecycleOwner.get().lifecycle.currentState
+                .isAtLeast(Lifecycle.State.STARTED)
             ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
                     isPaused = false
@@ -242,32 +256,55 @@ class KindeClient private constructor(
     }
 
     internal fun detachListener(listener: SDKListener) {
+        // Removes one attachment only: a listener instance shared by several
+        // facades stays subscribed until its last facade is destroyed.
         listeners.remove(listener)
     }
 
     internal fun attachEndSessionLauncher(launcher: EndSessionLauncher, logoutRedirect: String) {
-        endSessionLauncher = launcher
-        attachedLogoutRedirect = logoutRedirect
+        endSessionRoutes.add(EndSessionRoute(launcher, logoutRedirect))
     }
 
     internal fun detachEndSessionLauncher(launcher: EndSessionLauncher) {
-        // Only clear if this facade is still the active one; a newer activity may
-        // have attached its own launcher before the old activity is destroyed.
-        if (endSessionLauncher === launcher) {
-            endSessionLauncher = null
-        }
+        endSessionRoutes.removeAll { it.launcher === launcher }
     }
 
+    @androidx.annotation.VisibleForTesting
+    internal fun activeEndSessionLauncher(): EndSessionLauncher? =
+        endSessionRoutes.lastOrNull()?.launcher
+
     private fun notifyNewToken(token: String) {
-        listeners.forEach { it.onNewToken(token) }
+        LinkedHashSet(listeners).forEach { it.onNewToken(token) }
     }
 
     private fun notifyLogout() {
-        listeners.forEach { it.onLogout() }
+        LinkedHashSet(listeners).forEach { it.onLogout() }
     }
 
     private fun notifyException(exception: Exception) {
-        listeners.forEach { it.onException(exception) }
+        val snapshot = LinkedHashSet(listeners)
+        if (snapshot.isEmpty()) {
+            // Nothing attached (e.g. client warmed up from Application.onCreate);
+            // surface the failure somewhere rather than dropping it silently.
+            android.util.Log.w("KindeSDK", "No SDKListener attached; dropping exception", exception)
+            return
+        }
+        snapshot.forEach { it.onException(exception) }
+    }
+
+    // Flow-level events (a cancelled or failed browser round-trip) go to the
+    // facade that initiated the flow when known, matching the pre-refactor
+    // per-activity behavior; session-level events still broadcast.
+    private fun notifyNewTokenTo(target: SDKListener?, token: String) {
+        target?.onNewToken(token) ?: notifyNewToken(token)
+    }
+
+    private fun notifyLogoutTo(target: SDKListener?) {
+        target?.onLogout() ?: notifyLogout()
+    }
+
+    private fun notifyExceptionTo(target: SDKListener?, exception: Exception) {
+        target?.onException(exception) ?: notifyException(exception)
     }
 
     /**
@@ -276,6 +313,13 @@ class KindeClient private constructor(
      * restored session, or a logout signal when no session exists.
      */
     internal fun notifyInitialState(listener: SDKListener) {
+        // Pre-refactor, every activity construction re-ran the keys fetch, so a
+        // transient failure self-healed on the next screen. Preserve that: retry
+        // whenever a facade attaches and keys are still missing.
+        if (store.getKeys().isNullOrEmpty()) {
+            initializeStoreData()
+        }
+
         val stateJson = store.getState()
         if (!stateJson.isNullOrEmpty()) {
             if (isAuthenticated()) {
@@ -465,7 +509,10 @@ class KindeClient private constructor(
         authorize(type, orgCode, null, params, null, null, null, loginRedirect, scopes, launch)
     }
 
-    internal fun logout(logoutRedirect: String? = null) {
+    internal fun logout(
+        logoutRedirect: String? = null,
+        launch: ((Intent) -> Unit)? = null
+    ) {
         synchronized(stateLock) {
             if (isLoggingOut) return
             isLoggingOut = true
@@ -477,7 +524,6 @@ class KindeClient private constructor(
 
         val effectiveDomain = runtimeDomain ?: configDomain
         val logoutServiceConfig = getServiceConfiguration(effectiveDomain)
-        val effectiveRedirect = logoutRedirect ?: attachedLogoutRedirect
 
         thread {
             synchronized(stateLock) {
@@ -497,19 +543,28 @@ class KindeClient private constructor(
                 }
             }
             tokenRefreshHandler.post {
-                val launcher = endSessionLauncher
-                if (launcher != null && effectiveRedirect != null) {
+                fun endSessionIntent(redirect: String): Intent {
                     val endSessionRequest = EndSessionRequest.Builder(logoutServiceConfig)
-                        .setPostLogoutRedirectUri(effectiveRedirect.toUri())
-                        .setAdditionalParameters(mapOf(REDIRECT_PARAM_NAME to effectiveRedirect))
+                        .setPostLogoutRedirectUri(redirect.toUri())
+                        .setAdditionalParameters(mapOf(REDIRECT_PARAM_NAME to redirect))
                         .setState(null)
                         .build()
-                    launcher.launchEndSession(authService.getEndSessionRequestIntent(endSessionRequest))
-                } else {
-                    // No activity is attached (e.g. a background refresh failed after the
-                    // UI was destroyed), so the end-session browser round-trip is
-                    // impossible. Clear the local session directly.
-                    completeLogoutLocally()
+                    return authService.getEndSessionRequestIntent(endSessionRequest)
+                }
+
+                val fallbackRoute = endSessionRoutes.lastOrNull()
+                when {
+                    // The initiating facade supplied its own launcher: use it with
+                    // its own redirect, exactly like the login flows do.
+                    launch != null && logoutRedirect != null ->
+                        launch(endSessionIntent(logoutRedirect))
+                    // Background-triggered logout: route through any alive facade,
+                    // with the redirect that facade was configured with.
+                    fallbackRoute != null ->
+                        fallbackRoute.launcher.launchEndSession(endSessionIntent(fallbackRoute.logoutRedirect))
+                    // No activity is attached at all, so the end-session browser
+                    // round-trip is impossible. Clear the local session directly.
+                    else -> completeLogoutLocally()
                 }
             }
         }
@@ -530,14 +585,25 @@ class KindeClient private constructor(
         notifyLogout()
     }
 
-    internal fun onAuthorizationResult(resultCode: Int, data: Intent?) {
+    internal fun onAuthorizationResult(
+        resultCode: Int,
+        data: Intent?,
+        originListener: SDKListener? = null
+    ) {
         if (resultCode == Activity.RESULT_CANCELED) {
             val wasHandlingInvitation = invitationState.isHandling
-            invitationState.completeHandling()
+            if (wasHandlingInvitation) {
+                // Fully forget an abandoned invitation so tapping the same
+                // invitation link (or retrying manually) can start the flow again;
+                // dedupe is only meant to prevent re-processing after success.
+                invitationState.reset()
+            } else {
+                invitationState.completeHandling()
+            }
 
             if (data != null) {
                 val ex = AuthorizationException.fromIntent(data)
-                ex?.let { notifyException(AuthException("${ex.error} ${ex.errorDescription}")) }
+                ex?.let { notifyExceptionTo(originListener, AuthException("${ex.error} ${ex.errorDescription}")) }
                 clearRuntimeOverrides()
             }
 
@@ -548,9 +614,9 @@ class KindeClient private constructor(
             }
 
             if (isAuthenticated()) {
-                synchronized(stateLock) { state.accessToken }?.let { notifyNewToken(it) }
+                synchronized(stateLock) { state.accessToken }?.let { notifyNewTokenTo(originListener, it) }
             } else {
-                notifyLogout()
+                notifyLogoutTo(originListener)
             }
         }
 
@@ -579,11 +645,17 @@ class KindeClient private constructor(
                 }
             }
             ex?.let {
-                notifyException(AuthException("${ex.error} ${ex.errorDescription}"))
-                invitationState.completeHandling()
+                notifyExceptionTo(originListener, AuthException("${ex.error} ${ex.errorDescription}"))
+                if (invitationState.isHandling) {
+                    // A failed invitation flow must stay retryable (see the
+                    // RESULT_CANCELED branch).
+                    invitationState.reset()
+                } else {
+                    invitationState.completeHandling()
+                }
                 refreshState()
                 if (!isAuthenticated()) {
-                    notifyLogout()
+                    notifyLogoutTo(originListener)
                 }
                 clearRuntimeOverrides()
             }
@@ -1417,8 +1489,8 @@ class KindeClient private constructor(
             instance = null
         }
 
-        private const val DOMAIN_KEY = "au.kinde.domain"
-        private const val CLIENT_ID_KEY = "au.kinde.clientId"
+        internal const val DOMAIN_KEY = "au.kinde.domain"
+        internal const val CLIENT_ID_KEY = "au.kinde.clientId"
         private const val AUDIENCE_KEY = "au.kinde.audience"
         private const val AUDIENCE_KEY_LEGACY = "audience"
 

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -1,22 +1,12 @@
 package au.kinde.sdk
 
-import android.app.Activity
-import android.content.pm.PackageManager
-import android.os.Handler
-import android.os.Looper
-import android.util.Base64.URL_SAFE
-import android.util.Base64.decode
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.net.toUri
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import au.kinde.sdk.api.ApiOptions
-import au.kinde.sdk.api.FeatureFlagsApi
-import au.kinde.sdk.api.OAuthApi
-import au.kinde.sdk.api.PermissionsApi
-import au.kinde.sdk.api.RolesApi
-import au.kinde.sdk.api.UsersApi
 import au.kinde.sdk.api.model.entitlements.EntitlementResponse
 import au.kinde.sdk.api.model.entitlements.EntitlementsResponse
 import au.kinde.sdk.api.model.CreateUser200Response
@@ -24,39 +14,25 @@ import au.kinde.sdk.api.model.CreateUserRequest
 import au.kinde.sdk.api.model.User
 import au.kinde.sdk.api.model.UserProfile
 import au.kinde.sdk.api.model.UserProfileV2
-import au.kinde.sdk.infrastructure.ApiClient
-import au.kinde.sdk.keys.Keys
-import au.kinde.sdk.keys.KeysApi
+import au.kinde.sdk.model.ClaimData
+import au.kinde.sdk.model.Flag
 import au.kinde.sdk.model.TokenType
-import au.kinde.sdk.store.Store
-import au.kinde.sdk.token.TokenApi
-import au.kinde.sdk.token.TokenRepository
 import au.kinde.sdk.utils.ClaimApi
 import au.kinde.sdk.utils.ClaimDelegate
 import au.kinde.sdk.utils.TokenProvider
-import au.kinde.sdk.utils.callApi
-import com.google.gson.Gson
-import net.openid.appauth.AuthState
-import net.openid.appauth.AuthorizationException
-import net.openid.appauth.AuthorizationRequest
-import net.openid.appauth.AuthorizationResponse
-import net.openid.appauth.AuthorizationService
-import net.openid.appauth.AuthorizationServiceConfiguration
-import net.openid.appauth.CodeVerifierUtil
-import net.openid.appauth.EndSessionRequest
-import net.openid.appauth.ResponseTypeValues
-import net.openid.appauth.TokenRequest
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.Signature
-import java.security.spec.RSAPublicKeySpec
-import kotlin.concurrent.thread
-import au.kinde.sdk.model.ClaimData
-import au.kinde.sdk.model.Flag
 
+/**
+ * Activity-scoped facade over the application-scoped [KindeClient].
+ *
+ * Construct one per activity, in `onCreate` (required: the browser result
+ * launchers must be registered before the activity is started). The facade owns
+ * only the browser plumbing for login/registration/logout; all token state,
+ * refresh scheduling and API access live in the shared [KindeClient], so they
+ * survive activity recreation, rotation and navigation.
+ *
+ * Tokens can also be read without any activity via
+ * `KindeClient.getInstance(context)` — for example from an OkHttp interceptor.
+ */
 class KindeSDK(
     private val activity: ComponentActivity,
     private val loginRedirect: String,
@@ -65,234 +41,37 @@ class KindeSDK(
     private val sdkListener: SDKListener
 ) : TokenProvider, ClaimApi by ClaimDelegate, DefaultLifecycleObserver {
 
-    private val gson = Gson()
-    private val serviceConfiguration: AuthorizationServiceConfiguration
-    @Volatile
-    private lateinit var state: AuthState
-    private val authService = AuthorizationService(activity)
+    private val client = KindeClient.getInstance(activity)
 
     private val launcher = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        val data = result.data
-
-        if (result.resultCode == Activity.RESULT_CANCELED) {
-            val wasHandlingInvitation = invitationState.isHandling
-            invitationState.completeHandling()
-
-            if (data != null) {
-                val ex = AuthorizationException.fromIntent(data)
-                ex?.let { sdkListener.onException(AuthException("${ex.error} ${ex.errorDescription}")) }
-                clearRuntimeOverrides()
-            }
-
-            refreshState()
-
-            if (wasHandlingInvitation) {
-                return@registerForActivityResult
-            }
-
-            if (isAuthenticated()) {
-                state.accessToken?.let { sdkListener.onNewToken(it) }
-            } else {
-                sdkListener.onLogout()
-            }
-        }
-
-        if (result.resultCode == Activity.RESULT_OK && data != null) {
-            val resp = AuthorizationResponse.fromIntent(data)
-            val ex = AuthorizationException.fromIntent(data)
-            synchronized(stateLock) {
-                if (isLoggingOut) return@registerForActivityResult
-                state.update(resp, ex)
-                store.saveState(state.jsonSerializeString())
-            }
-            resp?.let {
-                thread {
-                    synchronized(stateLock) {
-                        if (isLoggingOut) return@thread
-                        activeBackgroundOperations++
-                    }
-                    try {
-                        getToken(resp.createTokenExchangeRequest())
-                    } finally {
-                        synchronized(stateLock) {
-                            activeBackgroundOperations--
-                            stateLock.notifyAll()
-                        }
-                    }
-                }
-            }
-            ex?.let {
-                sdkListener.onException(AuthException("${ex.error} ${ex.errorDescription}"))
-                invitationState.completeHandling()
-                refreshState()
-                if (!isAuthenticated()) {
-                    sdkListener.onLogout()
-                }
-                clearRuntimeOverrides()
-            }
-        }
+        client.onAuthorizationResult(result.resultCode, result.data)
     }
 
     private val endTokenLauncher = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        val data = result.data
+        client.onEndSessionResult(result.resultCode, result.data)
+    }
 
-        when (result.resultCode) {
-            Activity.RESULT_CANCELED -> {
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-
-                synchronized(stateLock) {
-                    isLoggingOut = false
-                }
-                scheduleTokenRefresh()
-            }
-            Activity.RESULT_OK -> {
-                val storeToClean = store
-                clearRuntimeOverrides()
-
-                synchronized(stateLock) {
-                    apiClient.setBearerToken("")
-                    storeToClean.clearState()
-                    state = AuthState(getServiceConfiguration(configDomain))
-                    isLoggingOut = false
-                }
-
-                sdkListener.onLogout()
-
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-            }
-            else -> {
-                data?.let {
-                    val ex = AuthorizationException.fromIntent(it)
-                    ex?.let { sdkListener.onException(LogoutException("${ex.error} ${ex.errorDescription}")) }
-                }
-
-                synchronized(stateLock) {
-                    isLoggingOut = false
-                }
-                scheduleTokenRefresh()
-            }
+    private val endSessionLauncherBridge = object : KindeClient.EndSessionLauncher {
+        override fun launchEndSession(intent: Intent) {
+            endTokenLauncher.launch(intent)
         }
     }
 
-    private val configDomain: String
-    private val configClientId: String
-    private val audience: String?
-    // Runtime overrides for domain and clientId (cleared on logout)
-    @Volatile
-    private var runtimeDomain: String? = null
-    @Volatile
-    private var runtimeClientId: String? = null
-    private var store: Store
-    private lateinit var tokenRepository: TokenRepository
-    private val apiClient: ApiClient
-    private lateinit var keysApi: KeysApi
-    private lateinit var oAuthApi: OAuthApi
-    private lateinit var usersApi: UsersApi
-    private lateinit var permissionsApi: PermissionsApi
-    private lateinit var rolesApi: RolesApi
-    private lateinit var featureFlagsApi: FeatureFlagsApi
-    private val tokenRefreshHandler = Handler(Looper.getMainLooper())
-    @Volatile
-    private var tokenRefreshRunnable: Runnable? = null
-    @Volatile
-    private var isPaused = false
-    private var lastTokenUpdateTime = 0L
-    private val stateLock = Object()
-    private val refreshLock = Object()
-    private val domainSwitchLock = Object()
-    @Volatile
-    private var isRefreshing = false
-    @Volatile
-    private var isLoggingOut = false
-    @Volatile
-    private var activeBackgroundOperations = 0
-
-    // Centralized invitation state management
-    private val invitationState = InvitationState()
-
-    // Cache infrastructure for API responses
-    private data class CacheEntry<T>(
-        val data: T,
-        val timestamp: Long
-    )
-
-    @Volatile
-    private var permissionsCache: CacheEntry<ClaimData.Permissions>? = null
-
-    @Volatile
-    private var rolesCache: CacheEntry<ClaimData.Roles>? = null
-
-    @Volatile
-    private var flagsCache: CacheEntry<Map<String, Flag>>? = null
-
     init {
         activity.lifecycle.addObserver(this)
-        @Suppress("DEPRECATION")
-        val appInfo = activity.packageManager.getApplicationInfo(
-            activity.packageName,
-            PackageManager.GET_META_DATA
-        )
-        // Required configuration: fail fast so the SDK is never constructed in an
-        // invalid state. A missing value here is a developer/configuration error,
-        // not a runtime auth error, so it is thrown rather than routed through onException.
-        val metaData = appInfo.metaData
-            ?: throw IllegalStateException("No meta-data found in AndroidManifest; $DOMAIN_KEY and $CLIENT_ID_KEY are required")
-        configDomain = metaData.getString(DOMAIN_KEY)?.trim()?.takeIf { it.isNotBlank() }
-            ?: throw IllegalStateException("$DOMAIN_KEY is not present at meta-data")
-        configClientId = metaData.getString(CLIENT_ID_KEY)?.trim()?.takeIf { it.isNotBlank() }
-            ?: throw IllegalStateException("$CLIENT_ID_KEY is not present at meta-data")
-        // Prefer the namespaced key; fall back to the legacy non-namespaced "audience"
-        // key for backwards compatibility with apps configured before the rename.
-        // Blank/whitespace-only values are treated as missing so a blank namespaced
-        // key does not shadow a valid legacy value.
-        audience = metaData.getString(AUDIENCE_KEY)?.trim()?.takeIf { it.isNotBlank() }
-            ?: metaData.getString(AUDIENCE_KEY_LEGACY)?.trim()?.takeIf { it.isNotBlank() }
-        serviceConfiguration = getServiceConfiguration(configDomain)
-
-        store = Store(activity, configDomain)
-
-        val stateJson = store.getState()
-        state = if (!stateJson.isNullOrEmpty()) {
-            AuthState.jsonDeserialize(stateJson)
-        } else {
-            AuthState(serviceConfiguration)
-        }
-
-        apiClient = ApiClient(HTTPS.format(configDomain), authNames = arrayOf(BEARER_AUTH))
-
-        createServices()
-
-        initializeStoreData()
-
-        if (store.getKeys().isNullOrEmpty()) {
-            keysApi.getKeys().enqueue(object : Callback<Keys> {
-                override fun onResponse(call: Call<Keys>, response: Response<Keys>) {
-                    response.body()?.let { keys ->
-                        store.saveKeys(gson.toJson(keys))
-                    }
-                }
-
-                override fun onFailure(call: Call<Keys>, t: Throwable) {
-                    sdkListener.onException(Exception(t))
-                }
-            })
-        }
+        client.attachEndSessionLauncher(endSessionLauncherBridge, logoutRedirect)
+        client.attachListener(sdkListener)
 
         // Check for invitation_code in the launching intent
-        val invitationCode = activity.intent?.data?.getQueryParameter(INVITATION_CODE_PARAM_NAME)
-        if (!invitationCode.isNullOrEmpty() && !invitationState.isProcessed(invitationCode)) {
+        val invitationCode =
+            activity.intent?.data?.getQueryParameter(KindeClient.INVITATION_CODE_PARAM_NAME)
+        if (!invitationCode.isNullOrEmpty() && !client.invitationState.isProcessed(invitationCode)) {
             // Check if already resumed; if so, handle immediately, otherwise use observer
-            if (activity.lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.RESUMED)) {
+            if (activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
                 handleInvitation(invitationCode)
             } else {
                 // Use lifecycle observer to handle invitation after activity is resumed
@@ -306,95 +85,14 @@ class KindeSDK(
         }
 
         // Skip normal auth callbacks if handling invitation
-        if (!invitationState.isHandling) {
-            if (!stateJson.isNullOrEmpty()) {
-                if (isAuthenticated()) {
-                    state.accessToken?.let { accessToken ->
-                        apiClient.setBearerToken(accessToken)
-                        sdkListener.onNewToken(accessToken)
-                        scheduleTokenRefresh()
-                    }
-                }
-            } else {
-                sdkListener.onLogout()
-            }
-        }
-        ClaimDelegate.tokenProvider = this
-    }
-
-    /**
-     * Validates a domain string to ensure it's a valid hostname
-     * without scheme, path, whitespace, or special characters.
-     *
-     * Enforces RFC 1035 constraints:
-     * - Total length ≤ 255 characters
-     * - Each label (part between dots) ≤ 63 characters
-     * - Labels must start/end with alphanumeric, hyphens only in middle
-     *
-     * @param domain The domain to validate
-     * @return true if valid, false otherwise
-     */
-    private fun isValidDomain(domain: String): Boolean {
-        if (domain.isBlank()) return false
-
-        // Check for invalid characters and patterns
-        if (domain.contains("://") ||  // no scheme
-            domain.contains("/") ||    // no path
-            domain.contains("@") ||     // no credentials
-            domain.contains(" ") ||     // no whitespace
-            domain.contains("\t") ||    // no tabs
-            domain.contains("\n") ||    // no newlines
-            domain.contains("\r")
-        ) {    // no carriage returns
-            return false
-        }
-
-        // RFC 1035 compliant hostname validation with length constraints
-        // - Max 255 chars total
-        // - Each label max 63 chars
-        // - Labels start/end with alphanumeric, hyphens only in middle
-        val hostnameRegex =
-            "^(?!.{256,})[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$".toRegex()
-        return hostnameRegex.matches(domain)
-    }
-
-    /**
-     * Validates a client ID string to ensure it's non-blank
-     * and contains no whitespace or control characters.
-     *
-     * @param clientId The client ID to validate
-     * @return true if valid, false otherwise
-     */
-    private fun isValidClientId(clientId: String): Boolean {
-        if (clientId.isBlank()) return false
-        return clientId.none { it.isWhitespace() || it.isISOControl() }
-    }
-
-    /**
-     * Clears runtime overrides and resets to default configuration if needed
-     */
-    private fun clearRuntimeOverrides() {
-        val hadRuntimeDomain = runtimeDomain != null
-        runtimeDomain = null
-        runtimeClientId = null
-
-        if (hadRuntimeDomain) {
-            // Reset API client to default domain
-            apiClient.setBaseUrl(HTTPS.format(configDomain))
-            store = Store(activity, configDomain)
-            synchronized(stateLock) {
-                val defaultConfig = getServiceConfiguration(configDomain)
-                state = AuthState(defaultConfig)
-            }
-            createServices()
+        if (!client.isHandlingInvitation()) {
+            client.notifyInitialState(sdkListener)
         }
     }
 
-    override fun getToken(tokenType: TokenType): String? = synchronized(stateLock) {
-        if (tokenType == TokenType.ACCESS_TOKEN) state.accessToken else state.idToken
-    }
+    override fun getToken(tokenType: TokenType): String? = client.getToken(tokenType)
 
-    fun getRefreshToken(): String? = synchronized(stateLock) { state.refreshToken }
+    fun getRefreshToken(): String? = client.getRefreshToken()
 
     /**
      * Initiate login flow
@@ -416,12 +114,10 @@ class KindeSDK(
         invitationCode: String? = null,
         connectionId: String? = null
     ) {
-        if (!invitationCode.isNullOrBlank()) {
-            handleInvitation(invitationCode, type, orgCode)
-        } else {
-            val params = mutableMapOf<String, String>()
-            login(type, orgCode, loginHint, params, domain, clientId, connectionId)
-        }
+        client.login(
+            type, orgCode, loginHint, domain, clientId, invitationCode, connectionId,
+            loginRedirect, scopes
+        ) { launcher.launch(it) }
     }
 
     /**
@@ -448,20 +144,10 @@ class KindeSDK(
         invitationCode: String? = null,
         connectionId: String? = null
     ) {
-        val params = mutableMapOf<String, String>(
-            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE
-        )
-        if (!pricingTableKey.isNullOrBlank()) {
-            params[PRICING_TABLE_KEY_PARAM_NAME] = pricingTableKey
-        }
-        if (!planInterest.isNullOrBlank()) {
-            params[PLAN_INTEREST_PARAM_NAME] = planInterest
-        }
-        if (!invitationCode.isNullOrBlank()) {
-            handleInvitation(invitationCode, type, orgCode)
-        } else {
-            login(type, orgCode, loginHint, params, domain, clientId, connectionId)
-        }
+        client.register(
+            type, orgCode, loginHint, pricingTableKey, planInterest, domain, clientId,
+            invitationCode, connectionId, loginRedirect, scopes
+        ) { launcher.launch(it) }
     }
 
     /**
@@ -485,27 +171,10 @@ class KindeSDK(
         clientId: String? = null,
         connectionId: String? = null
     ) {
-        require(orgName.isNotBlank()) { "orgName cannot be blank" }
-        val params = mutableMapOf<String, String>(
-            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE,
-            CREATE_ORG_PARAM_NAME to true.toString(),
-            ORG_NAME_PARAM_NAME to orgName
-        )
-        if (!pricingTableKey.isNullOrBlank()) {
-            params[PRICING_TABLE_KEY_PARAM_NAME] = pricingTableKey
-        }
-        if (!planInterest.isNullOrBlank()) {
-            params[PLAN_INTEREST_PARAM_NAME] = planInterest
-        }
-        login(
-            type,
-            null,
-            null,
-            params,
-            domain,
-            clientId,
-            connectionId
-        )
+        client.createOrg(
+            type, orgName, pricingTableKey, planInterest, domain, clientId, connectionId,
+            loginRedirect, scopes
+        ) { launcher.launch(it) }
     }
 
     /**
@@ -521,62 +190,13 @@ class KindeSDK(
         type: GrantType? = null,
         orgCode: String? = null
     ) {
-        if (invitationState.isProcessed(invitationCode)) {
-            // Already processed this invitation code
-            return
+        client.handleInvitation(invitationCode, type, orgCode, loginRedirect, scopes) {
+            launcher.launch(it)
         }
-
-        invitationState.startHandling(invitationCode)
-
-        val params = mutableMapOf(
-            REGISTRATION_PAGE_PARAM_NAME to REGISTRATION_PAGE_PARAM_VALUE,
-            INVITATION_CODE_PARAM_NAME to invitationCode,
-            IS_INVITATION_PARAM_NAME to "true"
-        )
-        login(type, orgCode, null, params)
     }
 
     fun logout() {
-        synchronized(stateLock) {
-            if (isLoggingOut) return
-            isLoggingOut = true
-        }
-
-        clearCache()
-        invitationState.reset()
-        cancelTokenRefresh()
-
-        val effectiveDomain = runtimeDomain ?: configDomain
-        val logoutServiceConfig = getServiceConfiguration(effectiveDomain)
-
-        val endSessionRequest = EndSessionRequest.Builder(logoutServiceConfig)
-            .setPostLogoutRedirectUri(logoutRedirect.toUri())
-            .setAdditionalParameters(mapOf(REDIRECT_PARAM_NAME to logoutRedirect))
-            .setState(null)
-            .build()
-        val endSessionIntent = authService.getEndSessionRequestIntent(endSessionRequest)
-
-        thread {
-            synchronized(stateLock) {
-                val deadline = System.currentTimeMillis() + 5000
-                while (activeBackgroundOperations > 0) {
-                    val remainingMillis = deadline - System.currentTimeMillis()
-                    if (remainingMillis <= 0) {
-                        android.util.Log.w("KindeSDK", "Logout timeout waiting for $activeBackgroundOperations background operations")
-                        break
-                    }
-                    try {
-                        stateLock.wait(remainingMillis)
-                    } catch (ie: InterruptedException) {
-                        Thread.currentThread().interrupt()
-                        break
-                    }
-                }
-            }
-            tokenRefreshHandler.post {
-                endTokenLauncher.launch(endSessionIntent)
-            }
-        }
+        client.logout(logoutRedirect)
     }
 
     /**
@@ -584,40 +204,21 @@ class KindeSDK(
      * Call this method when you need to sync the in-memory state with storage,
      * especially when navigating between activities that may have modified the auth state.
      */
-    fun refreshState() {
-        synchronized(stateLock) {
-            val stateJson = store.getState()
-            if (!stateJson.isNullOrBlank()) {
-                state = AuthState.jsonDeserialize(stateJson)
-            }
-        }
-    }
+    fun refreshState() = client.refreshState()
 
     /**
      * Checks if the user is currently authenticated.
      * This method relies on shared preferences rather than in-memory state
      * to work correctly across multiple activities.
      */
-    fun isAuthenticated(): Boolean {
-        synchronized(stateLock) {
-            val stateJson = store.getState()
-            if (stateJson.isNullOrBlank()) return false
-            // Temporarily deserialize to check auth status without mutating instance state
-            val currentState = AuthState.jsonDeserialize(stateJson)
-            return currentState.isAuthorized && checkTokenWithState(currentState)
-        }
-    }
+    fun isAuthenticated(): Boolean = client.isAuthenticated()
 
     /**
      * Clears all cached API responses (permissions, roles, and feature flags).
      * Call this when you need to force fresh data on the next API call, or when switching contexts
      * (e.g., changing organizations).
      */
-    fun clearCache() {
-        permissionsCache = null
-        rolesCache = null
-        flagsCache = null
-    }
+    fun clearCache() = client.clearCache()
 
     /**
      * Check if the SDK is currently handling an invitation code.
@@ -625,26 +226,25 @@ class KindeSDK(
      *
      * @return true if an invitation code was detected and is being processed
      */
-    fun isHandlingInvitation() = invitationState.isHandling
+    fun isHandlingInvitation() = client.isHandlingInvitation()
 
-    fun getUser(): UserProfile? = callApi(oAuthApi.getUser())
+    fun getUser(): UserProfile? = client.getUser()
 
-    fun getUserProfileV2(): UserProfileV2? = callApi(oAuthApi.getUserProfileV2())
+    fun getUserProfileV2(): UserProfileV2? = client.getUserProfileV2()
 
-    fun getEntitlement(key: String): EntitlementResponse? = callApi(oAuthApi.getEntitlement(key))
+    fun getEntitlement(key: String): EntitlementResponse? = client.getEntitlement(key)
 
-    fun getEntitlements(): EntitlementsResponse? = callApi(oAuthApi.getEntitlements())
+    fun getEntitlements(): EntitlementsResponse? = client.getEntitlements()
 
     fun createUser(createUserRequest: CreateUserRequest? = null): CreateUser200Response? =
-        callApi(usersApi.createUser(createUserRequest))
+        client.createUser(createUserRequest)
 
     fun getUsers(
         sort: kotlin.String? = null,
         pageSize: kotlin.Int? = null,
         userId: kotlin.Int? = null,
         nextToken: kotlin.String? = null
-    ): kotlin.collections.List<User>? =
-        callApi(usersApi.getUsers(sort, pageSize, userId, nextToken))
+    ): kotlin.collections.List<User>? = client.getUsers(sort, pageSize, userId, nextToken)
 
     /**
      * Get all permissions for the authenticated user
@@ -653,39 +253,8 @@ class KindeSDK(
      *                Set useCache = false to bypass cache and force a fresh API call.
      * @return ClaimData.Permissions containing org code and list of permission keys
      */
-    // Permissions with forceApi support
-    fun getPermissions(options: ApiOptions? = null): ClaimData.Permissions {
-        return if (options?.forceApi == true) {
-            // Check cache first if caching is enabled
-            if (options.useCache) {
-                val cached = permissionsCache
-                if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
-                    return cached.data
-                }
-            }
-
-            // Fetch from API
-            val response = callApi(permissionsApi.getPermissions())
-                ?: throw Exception("Failed to fetch permissions from API - check network and authentication")
-            if (!response.success) {
-                throw Exception("Permissions API returned success: false")
-            }
-
-            val permissions = ClaimData.Permissions(
-                orgCode = response.data?.orgCode ?: "",
-                permissions = response.getPermissionKeys()
-            )
-
-            // Cache the result if caching is enabled
-            if (options.useCache) {
-                permissionsCache = CacheEntry(permissions, System.currentTimeMillis())
-            }
-
-            permissions
-        } else {
-            ClaimDelegate.getPermissions()
-        }
-    }
+    fun getPermissions(options: ApiOptions? = null): ClaimData.Permissions =
+        client.getPermissions(options)
 
     /**
      * Check if user has a specific permission
@@ -698,17 +267,8 @@ class KindeSDK(
      * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
      * @return ClaimData.Permission with orgCode and isGranted status
      */
-    fun getPermission(permission: String, options: ApiOptions? = null): ClaimData.Permission {
-        return if (options?.forceApi == true) {
-            val perms = getPermissions(options)
-            ClaimData.Permission(
-                orgCode = perms.orgCode,
-                isGranted = perms.permissions.contains(permission)
-            )
-        } else {
-            ClaimDelegate.getPermission(permission)
-        }
-    }
+    fun getPermission(permission: String, options: ApiOptions? = null): ClaimData.Permission =
+        client.getPermission(permission, options)
 
     /**
      * Get all roles for the authenticated user
@@ -717,39 +277,7 @@ class KindeSDK(
      *                Set useCache = false to bypass cache and force a fresh API call.
      * @return ClaimData.Roles containing org code and list of role keys
      */
-    // Roles with forceApi support
-    fun getRoles(options: ApiOptions? = null): ClaimData.Roles {
-        return if (options?.forceApi == true) {
-            // Check cache first if caching is enabled
-            if (options.useCache) {
-                val cached = rolesCache
-                if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
-                    return cached.data
-                }
-            }
-
-            // Fetch from API
-            val response = callApi(rolesApi.getRoles())
-                ?: throw Exception("Failed to fetch roles from API - check network and authentication")
-            if (!response.success) {
-                throw Exception("Roles API returned success: false")
-            }
-
-            val roles = ClaimData.Roles(
-                orgCode = response.data?.orgCode ?: "",
-                roles = response.getRoleKeys()
-            )
-
-            // Cache the result if caching is enabled
-            if (options.useCache) {
-                rolesCache = CacheEntry(roles, System.currentTimeMillis())
-            }
-
-            roles
-        } else {
-            ClaimDelegate.getRoles()
-        }
-    }
+    fun getRoles(options: ApiOptions? = null): ClaimData.Roles = client.getRoles(options)
 
     /**
      * Check if user has a specific role
@@ -762,17 +290,8 @@ class KindeSDK(
      * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
      * @return ClaimData.Role with orgCode and isGranted status
      */
-    fun getRole(role: String, options: ApiOptions? = null): ClaimData.Role {
-        return if (options?.forceApi == true) {
-            val roles = getRoles(options)
-            ClaimData.Role(
-                orgCode = roles.orgCode,
-                isGranted = roles.roles.contains(role)
-            )
-        } else {
-            ClaimDelegate.getRole(role)
-        }
-    }
+    fun getRole(role: String, options: ApiOptions? = null): ClaimData.Role =
+        client.getRole(role, options)
 
     /**
      * Get a boolean feature flag value
@@ -786,23 +305,8 @@ class KindeSDK(
      * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
      * @return The boolean flag value or defaultValue if not found
      */
-    // Feature flags with forceApi support
-    fun getBooleanFlag(code: String, defaultValue: Boolean? = null, options: ApiOptions? = null): Boolean? {
-        return if (options?.forceApi == true) {
-            val flags = fetchFlagsWithCache(options)
-            val flag = flags[code]
-            when {
-                flag == null -> defaultValue
-                flag.value is Boolean -> flag.value
-                else -> {
-                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected Boolean, got ${flag.type}")
-                    defaultValue
-                }
-            }
-        } else {
-            ClaimDelegate.getBooleanFlag(code, defaultValue)
-        }
-    }
+    fun getBooleanFlag(code: String, defaultValue: Boolean? = null, options: ApiOptions? = null): Boolean? =
+        client.getBooleanFlag(code, defaultValue, options)
 
     /**
      * Get a string feature flag value
@@ -816,22 +320,8 @@ class KindeSDK(
      * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
      * @return The string flag value or defaultValue if not found
      */
-    fun getStringFlag(code: String, defaultValue: String? = null, options: ApiOptions? = null): String? {
-        return if (options?.forceApi == true) {
-            val flags = fetchFlagsWithCache(options)
-            val flag = flags[code]
-            when {
-                flag == null -> defaultValue
-                flag.value is String -> flag.value
-                else -> {
-                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected String, got ${flag.type}")
-                    defaultValue
-                }
-            }
-        } else {
-            ClaimDelegate.getStringFlag(code, defaultValue)
-        }
-    }
+    fun getStringFlag(code: String, defaultValue: String? = null, options: ApiOptions? = null): String? =
+        client.getStringFlag(code, defaultValue, options)
 
     /**
      * Get an integer feature flag value
@@ -845,22 +335,8 @@ class KindeSDK(
      * @param options Optional API options. Use ApiOptions(forceApi = true) to fetch fresh data from API
      * @return The integer flag value or defaultValue if not found
      */
-    fun getIntegerFlag(code: String, defaultValue: Int? = null, options: ApiOptions? = null): Int? {
-        return if (options?.forceApi == true) {
-            val flags = fetchFlagsWithCache(options)
-            val flag = flags[code]
-            when {
-                flag == null -> defaultValue
-                flag.value is Number -> flag.value.toInt()
-                else -> {
-                    android.util.Log.w("KindeSDK", "Flag '$code' type mismatch: expected Integer, got ${flag.type}")
-                    defaultValue
-                }
-            }
-        } else {
-            ClaimDelegate.getIntegerFlag(code, defaultValue)
-        }
-    }
+    fun getIntegerFlag(code: String, defaultValue: Int? = null, options: ApiOptions? = null): Int? =
+        client.getIntegerFlag(code, defaultValue, options)
 
     /**
      * Get all feature flags for the authenticated user
@@ -869,540 +345,17 @@ class KindeSDK(
      *                Set useCache = false to bypass cache and force a fresh API call.
      * @return Map of flag codes to Flag objects
      */
-    fun getAllFlags(options: ApiOptions? = null): Map<String, Flag> {
-        return if (options?.forceApi == true) {
-            fetchFlagsWithCache(options)
-        } else {
-            ClaimDelegate.getAllFlags()
-        }
-    }
-
-    /**
-     * Helper method to fetch feature flags from API with caching support
-     */
-    private fun fetchFlagsWithCache(options: ApiOptions): Map<String, Flag> {
-        // Check cache first if caching is enabled
-        if (options.useCache) {
-            val cached = flagsCache
-            if (cached != null && System.currentTimeMillis() - cached.timestamp < CACHE_TTL_MS) {
-                return cached.data
-            }
-        }
-
-        // Fetch from API
-        val response = callApi(featureFlagsApi.getFeatureFlags())
-            ?: throw Exception("Failed to fetch feature flags from API - check network and authentication")
-        if (!response.success) {
-            throw Exception("Feature flags API returned success: false")
-        }
-
-        val flags = response.toFlagMap()
-
-        // Cache the result if caching is enabled
-        if (options.useCache) {
-            flagsCache = CacheEntry(flags, System.currentTimeMillis())
-        }
-
-        return flags
-    }
-
-    private fun login(
-        type: GrantType? = null,
-        orgCode: String? = null,
-        loginHint: String? = null,
-        additionalParams: Map<String, String>,
-        customDomain: String? = null,
-        customClientId: String? = null,
-        connectionId: String? = null
-    ) {
-        // Validate and store runtime overrides if provided
-        customDomain?.let {
-            if (!isValidDomain(it)) {
-                sdkListener.onException(
-                    IllegalArgumentException(
-                        "Invalid domain: '$it'. Domain must be a valid hostname without scheme, path, or special characters."
-                    )
-                )
-                return
-            }
-            runtimeDomain = it
-        }
-        customClientId?.let {
-            if (!isValidClientId(it)) {
-                sdkListener.onException(
-                    IllegalArgumentException(
-                        "Invalid client ID: '$it'. Client ID must be non-blank and contain no whitespace or control characters."
-                    )
-                )
-                return
-            }
-            runtimeClientId = it
-        }
-
-        // Use runtime values if set, otherwise fall back to config
-        val effectiveDomain = runtimeDomain ?: configDomain
-        val effectiveClientId = runtimeClientId ?: configClientId
-
-        // Reconfigure API client if domain changed
-        reconfigureApiClientIfNeeded(effectiveDomain)
-
-        // Create service configuration with effective domain
-        val loginServiceConfig = getServiceConfiguration(effectiveDomain)
-
-        val verifier =
-            if (type == GrantType.PKCE) CodeVerifierUtil.generateRandomCodeVerifier() else null
-        val authRequestBuilder = AuthorizationRequest.Builder(
-            loginServiceConfig, // the authorization service configuration
-            effectiveClientId, // the client ID (config or runtime override)
-            ResponseTypeValues.CODE, // the response_type value: we want a code
-            loginRedirect.toUri()
-        )
-            .setCodeVerifier(verifier)
-            .setAdditionalParameters(
-                buildMap {
-                    putAll(additionalParams)
-                    audience?.let {
-                        put(AUDIENCE_PARAM_NAME, audience)
-                    }
-                    orgCode?.let {
-                        put(ORG_CODE_PARAM_NAME, orgCode)
-                    }
-                    connectionId?.let {
-                        put(CONNECTION_ID_PARAM_NAME, connectionId)
-                    }
-                }
-            )
-
-        // Extract and set login_hint if it's provided in additionalParams and is not empty.
-        loginHint?.takeIf { it.isNotEmpty() }?.let {
-            authRequestBuilder.setLoginHint(it)
-        }
-
-        val authRequest = authRequestBuilder
-            .setNonce(null)
-            .setScopes(scopes)
-            .build()
-        val authIntent = authService.getAuthorizationRequestIntent(authRequest)
-        launcher.launch(authIntent)
-    }
-
-    private fun getToken(tokenRequest: TokenRequest, notifyListener: Boolean = true): Boolean {
-        // Check if logout is in progress
-        synchronized(stateLock) {
-            if (isLoggingOut) return false
-        }
-
-        val grantType = tokenRequest.grantType
-
-        // For refresh token requests, use synchronized block to prevent concurrent refreshes
-        if (grantType == "refresh_token") {
-            synchronized(refreshLock) {
-                while (isRefreshing) {
-                    try {
-                        refreshLock.wait()
-                    } catch (ie: InterruptedException) {
-                        Thread.currentThread().interrupt()
-                        return false
-                    }
-                }
-                // Double-check logout flag after waiting
-                synchronized(stateLock) {
-                    if (isLoggingOut) return false
-                }
-                isRefreshing = true
-            }
-        }
-
-        val (resp, ex) = tokenRepository.getToken(
-            authState = state,
-            tokenRequest = tokenRequest
-        )
-
-        if (resp != null) {
-            // Check logout flag first, then clear isRefreshing if needed (avoid nested locks)
-            val wasLoggingOut = synchronized(stateLock) { isLoggingOut }
-            if (wasLoggingOut) {
-                if (grantType == "refresh_token") {
-                    synchronized(refreshLock) {
-                        isRefreshing = false
-                        refreshLock.notifyAll()
-                    }
-                }
-                return false
-            }
-
-            var shouldNotify = false
-            var snapshotToken = ""
-            synchronized(stateLock) {
-                if (!isLoggingOut) {
-                    state.update(resp, ex)
-                    apiClient.setBearerToken(state.accessToken.orEmpty())
-                    store.saveState(state.jsonSerializeString())
-                    lastTokenUpdateTime = System.currentTimeMillis()
-
-                    if (notifyListener && !state.accessToken.isNullOrEmpty()) {
-                        shouldNotify = true
-                        snapshotToken = state.accessToken.orEmpty()
-                    }
-                }
-            }
-            if (shouldNotify) {
-                sdkListener.onNewToken(snapshotToken)
-            }
-
-            if (grantType != "refresh_token") {
-                // Reset invitation handling flag after successful interactive authentication
-                invitationState.completeHandling()
-            }
-
-            if (grantType == "refresh_token") {
-                synchronized(refreshLock) {
-                    // Clear isRefreshing outside of stateLock to avoid nested lock
-                    isRefreshing = false
-                    refreshLock.notifyAll()
-                }
-            }
-
-            // Check if logout happened during state update
-            val logoutHappened = synchronized(stateLock) { isLoggingOut }
-            if (logoutHappened) {
-                return false
-            }
-
-            scheduleTokenRefresh()
-        } else {
-            // Check if this is a 401/invalid_grant error (invalid refresh token)
-            val isInvalidRefreshToken = ex?.let { exception ->
-                val is401 = exception.message?.contains("401") == true
-                val isInvalidGrant = exception.error == "invalid_grant"
-                is401 || isInvalidGrant
-            } ?: false
-
-            ex?.let { sdkListener.onException(TokenException("${ex.error} ${ex.errorDescription}")) }
-
-            // Always logout on invalid refresh token (401/invalid_grant)
-            // For other errors, only logout if notifyListener is true (manual refresh)
-            try {
-                if (isInvalidRefreshToken || notifyListener) {
-                    logout()
-                }
-            } finally {
-                if (grantType == "refresh_token") {
-                    synchronized(refreshLock) {
-                        isRefreshing = false
-                        refreshLock.notifyAll()
-                    }
-                }
-            }
-        }
-        return resp != null
-    }
-
-    /*
-    * checkToken should only verify token signature, not trigger refresh
-    * Token refresh is handled automatically by scheduleTokenRefresh()
-    */
-    private fun checkToken() = checkTokenWithState(state)
-
-    private fun checkTokenWithState(authState: AuthState): Boolean {
-        if (authState.isAuthorized) {
-            store.getKeys()?.let { keysString ->
-                try {
-                    gson.fromJson(keysString, Keys::class.java)?.let { keys ->
-                        keys.keys.firstOrNull()?.let { key ->
-                            val jwt = authState.accessToken.orEmpty()
-
-                            val exponentB: ByteArray = decode(key.exponent, URL_SAFE)
-                            val modulusB: ByteArray = decode(key.modulus, URL_SAFE)
-                            val bigExponent = BigInteger(1, exponentB)
-                            val bigModulus = BigInteger(1, modulusB)
-                            val publicKey = KeyFactory.getInstance(key.keyType)
-                                .generatePublic(RSAPublicKeySpec(bigModulus, bigExponent))
-                            val signedData: String = jwt.substring(0, jwt.lastIndexOf("."))
-                            val signatureB64u: String =
-                                jwt.substring(jwt.lastIndexOf(".") + 1, jwt.length)
-                            val signature: ByteArray = decode(signatureB64u, URL_SAFE)
-                            val sig: Signature = Signature.getInstance("SHA256withRSA")
-                            sig.initVerify(publicKey)
-                            sig.update(signedData.toByteArray())
-                            return sig.verify(signature)
-                        }
-                    }
-                } catch (ex: Exception) {
-                    sdkListener.onException(ex)
-                }
-            }
-        }
-        return false
-    }
-
-    private fun <T> callApi(call: Call<T>, refreshed: Boolean = false): T? {
-        val (data, exception) = call.callApi(state, refreshed = refreshed)
-        if (data != null) {
-            return data
-        }
-        if (exception != null) {
-            if (exception is TokenExpiredException) {
-                // Use notifyListener=false to prevent logout on API call token refresh
-                if (getToken(state.createTokenRefreshRequest(), notifyListener = false)) {
-                    return callApi(call.clone(), refreshed = true)
-                }
-            } else {
-                sdkListener.onException(exception)
-            }
-        }
-        return null
-    }
-
-    private fun getExpireEpochSeconds(tokenType: TokenType): Long? {
-        val expClaim = getClaim("exp", tokenType)
-        return when (val value = expClaim.value) {
-            is Long -> value
-            is String -> value.toLongOrNull()
-            is Number -> value.toLong()
-            else -> null
-        }
-    }
-
-    private fun scheduleTokenRefresh() {
-        cancelTokenRefresh()
-
-        if (isPaused) {
-            return
-        }
-
-        val expireEpochSeconds = getExpireEpochSeconds(TokenType.ACCESS_TOKEN) ?: return
-
-        val expireEpochMillis = expireEpochSeconds * 1000
-        val refreshTimeMillis = expireEpochMillis - TOKEN_REFRESH_BUFFER_MS
-        val currentTimeMillis = System.currentTimeMillis()
-        val delayMillis = refreshTimeMillis - currentTimeMillis
-
-        val retryDelayMs = 10_000L
-
-        if (delayMillis > 0) {
-            postTokenRefresh(delayMillis, retryDelayMs)
-        } else {
-            // Already inside the buffer window — refresh right away
-            postTokenRefresh(0L, retryDelayMs)
-        }
-    }
-
-    private fun postTokenRefresh(delayMillis: Long, retryDelayMs: Long) {
-        tokenRefreshRunnable = createTokenRefreshRunnable(retryDelayMs)
-        tokenRefreshHandler.postDelayed(tokenRefreshRunnable!!, delayMillis)
-    }
-
-    private fun createTokenRefreshRunnable(retryDelayMs: Long = 10_000L): Runnable {
-        return Runnable {
-            thread {
-                synchronized(stateLock) {
-                    if (isLoggingOut) return@thread
-                    activeBackgroundOperations++
-                }
-                try {
-                    val tokenRequest = try {
-                        state.createTokenRefreshRequest()
-                    } catch (e: IllegalStateException) {
-                        return@thread
-                    }
-                    val success = getToken(tokenRequest, notifyListener = false)
-                    if (!success && !isLoggingOut) {
-                        postTokenRefresh(retryDelayMs, retryDelayMs)
-                    }
-                } finally {
-                    synchronized(stateLock) {
-                        activeBackgroundOperations--
-                        stateLock.notifyAll()
-                    }
-                }
-            }
-        }
-    }
-
-    private fun cancelTokenRefresh() {
-        tokenRefreshRunnable?.let { tokenRefreshHandler.removeCallbacks(it) }
-        tokenRefreshRunnable = null
-    }
-
-    /**
-     * Reconfigures the API clients if the domain has changed from the originally configured domain.
-     * This ensures API calls go to the correct endpoint when using runtime domain overrides.
-     */
-    private fun reconfigureApiClientIfNeeded(effectiveDomain: String) {
-        synchronized(domainSwitchLock) {
-            val currentBaseUrl = apiClient.getBaseUrl()
-            val expectedBaseUrl = HTTPS.format(effectiveDomain)
-
-            if (currentBaseUrl != expectedBaseUrl) {
-                // Clear cached data from the previous domain to prevent stale data issues
-                clearCache()
-
-                // Cancel any scheduled token refresh to prevent sending old tokens to new domain
-                cancelTokenRefresh()
-
-                // Clear bearer token before switching domain to prevent token leakage
-                apiClient.setBearerToken("")
-
-                apiClient.setBaseUrl(expectedBaseUrl)
-
-                // Recreate Store with new domain for domain-specific SharedPreferences
-                store = Store(activity, effectiveDomain)
-
-                // Update the state's serviceConfiguration to use the new domain
-                val newServiceConfig = getServiceConfiguration(effectiveDomain)
-                synchronized(stateLock) {
-                    // Load any existing state from new domain's store
-                    val stateJson = store.getState()
-                    if (!stateJson.isNullOrEmpty()) {
-                        state = AuthState.jsonDeserialize(stateJson)
-                    } else {
-                        // Create new state with the new service configuration
-                        // This will be used for the token exchange after login
-                        state = AuthState(newServiceConfig)
-                    }
-                }
-
-                createServices()
-
-                // Initialize data for the new domain-specific store
-                initializeStoreData()
-            }
-        }
-    }
-
-    private fun createServices() {
-        // Recreate all service instances to use the updated Retrofit client
-        tokenRepository = TokenRepository(apiClient.createService(TokenApi::class.java), BuildConfig.SDK_VERSION)
-        keysApi = apiClient.createService(KeysApi::class.java)
-        oAuthApi = apiClient.createService(OAuthApi::class.java)
-        usersApi = apiClient.createService(UsersApi::class.java)
-        permissionsApi = apiClient.createService(PermissionsApi::class.java)
-        rolesApi = apiClient.createService(RolesApi::class.java)
-        featureFlagsApi = apiClient.createService(FeatureFlagsApi::class.java)
-    }
-
-    private fun getServiceConfiguration(effectiveDomain: String): AuthorizationServiceConfiguration {
-        return AuthorizationServiceConfiguration(
-            AUTH_URL.format(effectiveDomain).toUri(),
-            TOKEN_URL.format(effectiveDomain).toUri(),
-            null,
-            LOGOUT_URL.format(effectiveDomain).toUri()
-        )
-    }
-
-    /**
-     * Initializes domain-specific data including keys and authentication state.
-     * This should be called when setting up the SDK or when switching domains.
-     */
-    private fun initializeStoreData() {
-        // Capture store reference to prevent race condition if domain switches during async request
-        val storeForRequest = store
-
-        // Fetch and store keys for the domain if not already present
-        if (storeForRequest.getKeys().isNullOrEmpty()) {
-            keysApi.getKeys().enqueue(object : Callback<Keys> {
-                override fun onResponse(call: Call<Keys>, response: Response<Keys>) {
-                    response.body()?.let { keys ->
-                        // Use captured store reference to ensure keys are saved to correct store
-                        storeForRequest.saveKeys(gson.toJson(keys))
-                        // Only set up auth state if this store is still the current one
-                        if (store == storeForRequest) {
-                            setupAuthState()
-                        }
-                    }
-                }
-
-                override fun onFailure(call: Call<Keys>, t: Throwable) {
-                    sdkListener.onException(Exception(t))
-                    // Don't proceed with auth setup if keys fetch failed
-                }
-            })
-        } else {
-            // Keys already exist, set up auth state immediately
-            // Only set up if store hasn't changed
-            if (store == storeForRequest) {
-                setupAuthState()
-            }
-        }
-    }
-
-    /**
-     * Sets up authentication state after keys are confirmed to be available.
-     * This ensures signature verification can succeed.
-     */
-    private fun setupAuthState() {
-        // Load and setup authentication state from domain-specific store
-        val stateJson = store.getState()
-        if (!stateJson.isNullOrEmpty()) {
-            refreshState()
-            if (isAuthenticated()) {
-                state.accessToken?.let { accessToken ->
-                    apiClient.setBearerToken(accessToken)
-                    sdkListener.onNewToken(accessToken)
-                    scheduleTokenRefresh()
-                }
-            }
-        }
-        // Note: We don't call onLogout() when state is missing because
-        // missing state doesn't mean the user logged out - it could be
-        // first-time initialization or a domain switch during login.
-        // onLogout() is only called in the actual logout flow.
-    }
-
-    override fun onPause(owner: LifecycleOwner) {
-        super.onPause(owner)
-        isPaused = true
-        // Cancel scheduled refresh when app goes to background to save battery
-        cancelTokenRefresh()
-    }
-
-    override fun onResume(owner: LifecycleOwner) {
-        super.onResume(owner)
-        isPaused = false
-        // Refresh state from storage and check if token needs refresh when app comes to foreground
-        refreshState()
-        if (isAuthenticated()) {
-            scheduleTokenRefresh()
-        }
-    }
+    fun getAllFlags(options: ApiOptions? = null): Map<String, Flag> = client.getAllFlags(options)
 
     override fun onDestroy(owner: LifecycleOwner) {
         super.onDestroy(owner)
-        // Clean up resources
-        cancelTokenRefresh()
-        authService.dispose()
+        // Only this facade's plumbing dies with the activity; token state and the
+        // refresh schedule live on in the shared KindeClient.
+        client.detachListener(sdkListener)
+        client.detachEndSessionLauncher(endSessionLauncherBridge)
     }
 
     companion object {
-        private const val DOMAIN_KEY = "au.kinde.domain"
-        private const val CLIENT_ID_KEY = "au.kinde.clientId"
-        private const val AUDIENCE_KEY = "au.kinde.audience"
-        private const val AUDIENCE_KEY_LEGACY = "audience"
-
-        private const val AUTH_URL = "https://%s/oauth2/auth"
-        private const val TOKEN_URL = "https://%s/oauth2/token"
-        private const val LOGOUT_URL = "https://%s/logout"
-
-        private const val REGISTRATION_PAGE_PARAM_NAME = "start_page"
-        private const val REGISTRATION_PAGE_PARAM_VALUE = "registration"
-        private const val AUDIENCE_PARAM_NAME = "audience"
-        private const val CREATE_ORG_PARAM_NAME = "is_create_org"
-        private const val ORG_NAME_PARAM_NAME = "org_name"
-        private const val ORG_CODE_PARAM_NAME = "org_code"
-        private const val PRICING_TABLE_KEY_PARAM_NAME = "pricing_table_key"
-        private const val PLAN_INTEREST_PARAM_NAME = "plan_interest"
-        private const val CONNECTION_ID_PARAM_NAME = "connection_id"
-        private const val REDIRECT_PARAM_NAME = "redirect"
-        private const val INVITATION_CODE_PARAM_NAME = "invitation_code"
-        private const val IS_INVITATION_PARAM_NAME = "is_invitation"
-
-        private const val HTTPS = "https://%s/"
-        private const val BEARER_AUTH = "kindeBearerAuth"
         private val DEFAULT_SCOPES = listOf("openid", "offline", "email", "profile")
-
-        // Cache configuration
-        private const val CACHE_TTL_MS = 60_000L // 60 seconds
-        private const val TOKEN_REFRESH_BUFFER_MS = 10_000L // 10 seconds
     }
 }

--- a/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
+++ b/sdk/src/main/kotlin/au/kinde/sdk/KindeSDK.kt
@@ -46,7 +46,7 @@ class KindeSDK(
     private val launcher = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        client.onAuthorizationResult(result.resultCode, result.data)
+        client.onAuthorizationResult(result.resultCode, result.data, sdkListener)
     }
 
     private val endTokenLauncher = activity.registerForActivityResult(
@@ -196,7 +196,7 @@ class KindeSDK(
     }
 
     fun logout() {
-        client.logout(logoutRedirect)
+        client.logout(logoutRedirect) { endTokenLauncher.launch(it) }
     }
 
     /**

--- a/sdk/src/test/kotlin/au/kinde/sdk/InvitationStateTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/InvitationStateTest.kt
@@ -1,0 +1,53 @@
+package au.kinde.sdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InvitationStateTest {
+
+    @Test
+    fun `startHandling marks code as processed and handling`() {
+        val state = InvitationState()
+
+        state.startHandling("code-1")
+
+        assertTrue(state.isHandling)
+        assertTrue(state.isProcessed("code-1"))
+        assertEquals("code-1", state.processedCode)
+    }
+
+    @Test
+    fun `different code is not considered processed`() {
+        val state = InvitationState()
+
+        state.startHandling("code-1")
+
+        assertFalse(state.isProcessed("code-2"))
+    }
+
+    @Test
+    fun `completeHandling clears handling flag but keeps processed code`() {
+        val state = InvitationState()
+        state.startHandling("code-1")
+
+        state.completeHandling()
+
+        assertFalse(state.isHandling)
+        assertTrue(state.isProcessed("code-1"))
+    }
+
+    @Test
+    fun `reset clears both handling flag and processed code`() {
+        val state = InvitationState()
+        state.startHandling("code-1")
+
+        state.reset()
+
+        assertFalse(state.isHandling)
+        assertFalse(state.isProcessed("code-1"))
+        assertNull(state.processedCode)
+    }
+}

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
@@ -1,0 +1,161 @@
+package au.kinde.sdk
+
+import android.app.Activity
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import au.kinde.sdk.model.TokenType
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KindeClientTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetSingleton() {
+        KindeClient.resetInstance()
+    }
+
+    @Test
+    fun `getInstance returns the same instance on every call`() {
+        installKindeMetaData(context)
+
+        val first = KindeClient.getInstance(context)
+        val second = KindeClient.getInstance(context)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `construction fails fast when domain meta-data is missing`() {
+        installKindeMetaData(context, domain = null)
+
+        assertThrows(IllegalStateException::class.java) {
+            KindeClient.getInstance(context)
+        }
+    }
+
+    @Test
+    fun `construction fails fast when clientId meta-data is missing`() {
+        installKindeMetaData(context, clientId = null)
+
+        assertThrows(IllegalStateException::class.java) {
+            KindeClient.getInstance(context)
+        }
+    }
+
+    @Test
+    fun `config domain is read and trimmed from meta-data`() {
+        installKindeMetaData(context, domain = "  $TEST_DOMAIN  ")
+
+        val client = KindeClient.getInstance(context)
+
+        assertEquals(TEST_DOMAIN, client.configDomain)
+    }
+
+    @Test
+    fun `getToken and isAuthenticated report signed-out state with empty store`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+
+        assertNull(client.getToken(TokenType.ACCESS_TOKEN))
+        assertNull(client.getToken(TokenType.ID_TOKEN))
+        assertNull(client.getRefreshToken())
+        assertFalse(client.isAuthenticated())
+    }
+
+    @Test
+    fun `initial state replay fires onLogout for empty store`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+
+        client.notifyInitialState(listener)
+
+        assertEquals(1, listener.logoutCount)
+        assertTrue(listener.tokens.isEmpty())
+    }
+
+    @Test
+    fun `events broadcast to all attached listeners`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listenerA = RecordingListener()
+        val listenerB = RecordingListener()
+        client.attachListener(listenerA)
+        client.attachListener(listenerB)
+
+        // RESULT_OK on the end-session launcher is a completed logout.
+        client.onEndSessionResult(Activity.RESULT_OK, null)
+
+        assertEquals(1, listenerA.logoutCount)
+        assertEquals(1, listenerB.logoutCount)
+    }
+
+    @Test
+    fun `detached listener stops receiving events`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listenerA = RecordingListener()
+        val listenerB = RecordingListener()
+        client.attachListener(listenerA)
+        client.attachListener(listenerB)
+
+        client.detachListener(listenerB)
+        client.onEndSessionResult(Activity.RESULT_OK, null)
+
+        assertEquals(1, listenerA.logoutCount)
+        assertEquals(0, listenerB.logoutCount)
+    }
+
+    @Test
+    fun `logout with no attached launcher clears the session locally`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+        client.attachListener(listener)
+
+        client.logout()
+
+        assertTrue(
+            "expected local logout to complete and notify onLogout",
+            awaitCondition { listener.logoutCount == 1 }
+        )
+        assertFalse(client.isAuthenticated())
+        // A second logout must work: the isLoggingOut flag has to be reset.
+        client.logout()
+        assertTrue(
+            "expected a second logout to complete (isLoggingOut was reset)",
+            awaitCondition { listener.logoutCount == 2 }
+        )
+    }
+
+    @Test
+    fun `cancelled end-session resets logging-out flag so logout can be retried`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+        client.attachListener(listener)
+
+        // Simulate the browser round-trip being cancelled by the user.
+        client.onEndSessionResult(Activity.RESULT_CANCELED, null)
+
+        // Session must remain usable and a fresh logout must still be possible.
+        client.logout()
+        assertTrue(
+            "expected logout after a cancelled end-session to complete",
+            awaitCondition { listener.logoutCount == 1 }
+        )
+    }
+}

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
@@ -258,6 +258,23 @@ class KindeClientTest {
     }
 
     @Test
+    fun `refresh is skipped only when another refresh rotated the token mid-wait`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+
+        // A concurrent refresh rotated the token: replaying the old one would be
+        // treated as reuse, so the stale request must be skipped.
+        assertTrue(client.shouldSkipStaleRefresh("old-token", "rotated-token"))
+        // Same token means the earlier refresh failed or didn't rotate: retrying
+        // with it is the correct behavior.
+        assertFalse(client.shouldSkipStaleRefresh("same-token", "same-token"))
+        // Missing either side (fresh login, cleared session): proceed and let the
+        // normal error handling decide.
+        assertFalse(client.shouldSkipStaleRefresh(null, "rotated-token"))
+        assertFalse(client.shouldSkipStaleRefresh("old-token", null))
+    }
+
+    @Test
     fun `cancelled end-session resets logging-out flag so logout can be retried`() {
         installKindeMetaData(context)
         val client = KindeClient.getInstance(context)

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
@@ -189,6 +189,75 @@ class KindeClientTest {
     }
 
     @Test
+    fun `logout completes locally when the browser launch fails`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+        client.attachListener(listener)
+        // Robolectric has no browser installed, so building the end-session
+        // intent throws inside AppAuth — the launch must fail, and logout must
+        // still complete instead of staying pending forever.
+        val launcher = object : KindeClient.EndSessionLauncher {
+            override fun launchEndSession(intent: android.content.Intent) = Unit
+        }
+        client.attachEndSessionLauncher(launcher, "test.scheme://logout")
+
+        client.logout()
+
+        assertTrue(
+            "expected logout to fall back to local completion",
+            awaitCondition { listener.logoutCount == 1 }
+        )
+        assertFalse(client.isLogoutInProgress())
+    }
+
+    @Test
+    fun `logout stuck on a lost end-session result can be retried`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+        client.attachListener(listener)
+        // Simulate a logout whose browser result was lost long ago.
+        client.markLoggingOutForTest(startedAtMs = 0L)
+
+        client.logout()
+
+        assertTrue(
+            "expected retried logout to complete after the stale one",
+            awaitCondition { listener.logoutCount == 1 }
+        )
+        assertFalse(client.isLogoutInProgress())
+    }
+
+    @Test
+    fun `recent pending logout is not restarted`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val listener = RecordingListener()
+        client.attachListener(listener)
+        client.markLoggingOutForTest(startedAtMs = System.currentTimeMillis())
+
+        client.logout()
+
+        // The first logout is still within its result window; the second call
+        // must not tear the session down underneath it.
+        awaitCondition(timeoutMs = 250) { false }
+        assertEquals(0, listener.logoutCount)
+        assertTrue(client.isLogoutInProgress())
+    }
+
+    @Test
+    fun `attaching a facade clears stale logout state`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        client.markLoggingOutForTest(startedAtMs = 0L)
+
+        client.notifyInitialState(RecordingListener())
+
+        assertFalse(client.isLogoutInProgress())
+    }
+
+    @Test
     fun `cancelled end-session resets logging-out flag so logout can be retried`() {
         installKindeMetaData(context)
         val client = KindeClient.getInstance(context)

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
@@ -280,11 +280,18 @@ class KindeClientTest {
         val client = KindeClient.getInstance(context)
         val listener = RecordingListener()
         client.attachListener(listener)
+        // A logout must actually be pending for the cancellation to have state to
+        // clear; a recent timestamp keeps the stale-recovery path out of play.
+        client.markLoggingOutForTest(startedAtMs = System.currentTimeMillis())
 
         // Simulate the browser round-trip being cancelled by the user.
         client.onEndSessionResult(Activity.RESULT_CANCELED, null)
 
+        assertFalse(client.isLogoutInProgress())
+
         // Session must remain usable and a fresh logout must still be possible.
+        // This only works if the cancellation cleared the flag: the pending logout
+        // was recent, so the stale-recovery path would not let a retry through.
         client.logout()
         assertTrue(
             "expected logout after a cancelled end-session to complete",

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeClientTest.kt
@@ -142,6 +142,53 @@ class KindeClientTest {
     }
 
     @Test
+    fun `back navigation keeps an earlier facade's end-session launcher available`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val launcherA = object : KindeClient.EndSessionLauncher {
+            override fun launchEndSession(intent: android.content.Intent) = Unit
+        }
+        val launcherB = object : KindeClient.EndSessionLauncher {
+            override fun launchEndSession(intent: android.content.Intent) = Unit
+        }
+
+        // Activity A attaches, activity B attaches on top, then B is destroyed
+        // (back navigation). A's launcher must remain the active fallback.
+        client.attachEndSessionLauncher(launcherA, "test.scheme://logout-a")
+        client.attachEndSessionLauncher(launcherB, "test.scheme://logout-b")
+        client.detachEndSessionLauncher(launcherB)
+
+        assertSame(launcherA, client.activeEndSessionLauncher())
+    }
+
+    @Test
+    fun `cancelled invitation flow can be retried`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        client.invitationState.startHandling("invite-1")
+
+        client.onAuthorizationResult(Activity.RESULT_CANCELED, null)
+
+        assertFalse(client.invitationState.isHandling)
+        assertFalse(client.invitationState.isProcessed("invite-1"))
+    }
+
+    @Test
+    fun `cancelled login notifies only the initiating listener`() {
+        installKindeMetaData(context)
+        val client = KindeClient.getInstance(context)
+        val initiator = RecordingListener()
+        val bystander = RecordingListener()
+        client.attachListener(initiator)
+        client.attachListener(bystander)
+
+        client.onAuthorizationResult(Activity.RESULT_CANCELED, null, initiator)
+
+        assertEquals(1, initiator.logoutCount)
+        assertEquals(0, bystander.logoutCount)
+    }
+
+    @Test
     fun `cancelled end-session resets logging-out flag so logout can be retried`() {
         installKindeMetaData(context)
         val client = KindeClient.getInstance(context)

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeSDKFacadeTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeSDKFacadeTest.kt
@@ -1,0 +1,107 @@
+package au.kinde.sdk
+
+import android.app.Activity
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.test.core.app.ApplicationProvider
+import au.kinde.sdk.model.TokenType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class KindeSDKFacadeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetSingleton() {
+        KindeClient.resetInstance()
+        installKindeMetaData(context)
+    }
+
+    private fun buildSdk(listener: SDKListener): Pair<org.robolectric.android.controller.ActivityController<ComponentActivity>, KindeSDK> {
+        val controller = Robolectric.buildActivity(ComponentActivity::class.java)
+        controller.create()
+        val sdk = KindeSDK(
+            activity = controller.get(),
+            loginRedirect = "test.scheme://callback",
+            logoutRedirect = "test.scheme://logout",
+            sdkListener = listener
+        )
+        return controller to sdk
+    }
+
+    @Test
+    fun `construction replays onLogout to its listener when no session exists`() {
+        val listener = RecordingListener()
+
+        buildSdk(listener)
+
+        assertEquals(1, listener.logoutCount)
+        assertEquals(0, listener.tokens.size)
+    }
+
+    @Test
+    fun `facade delegates token reads to the shared core`() {
+        val listener = RecordingListener()
+        val (_, sdk) = buildSdk(listener)
+
+        assertNull(sdk.getToken(TokenType.ACCESS_TOKEN))
+        assertNull(sdk.getRefreshToken())
+        assertFalse(sdk.isAuthenticated())
+    }
+
+    @Test
+    fun `two facades share one core and both listeners hear core events`() {
+        val listenerA = RecordingListener()
+        val listenerB = RecordingListener()
+        buildSdk(listenerA)
+        buildSdk(listenerB)
+        val initialA = listenerA.logoutCount
+        val initialB = listenerB.logoutCount
+
+        KindeClient.getInstance(context).onEndSessionResult(Activity.RESULT_OK, null)
+
+        assertEquals(initialA + 1, listenerA.logoutCount)
+        assertEquals(initialB + 1, listenerB.logoutCount)
+    }
+
+    @Test
+    fun `destroying the activity detaches its listener while others keep receiving`() {
+        val listenerA = RecordingListener()
+        val listenerB = RecordingListener()
+        val (controllerA, _) = buildSdk(listenerA)
+        buildSdk(listenerB)
+
+        controllerA.destroy()
+        val countAAfterDestroy = listenerA.logoutCount
+        val initialB = listenerB.logoutCount
+
+        KindeClient.getInstance(context).onEndSessionResult(Activity.RESULT_OK, null)
+
+        assertEquals(countAAfterDestroy, listenerA.logoutCount)
+        assertEquals(initialB + 1, listenerB.logoutCount)
+    }
+
+    @Test
+    fun `core state survives activity recreation`() {
+        val listenerA = RecordingListener()
+        val (controllerA, _) = buildSdk(listenerA)
+        val coreBefore = KindeClient.getInstance(context)
+
+        // Simulate a configuration change: old activity destroyed, new one created.
+        controllerA.destroy()
+        val listenerB = RecordingListener()
+        buildSdk(listenerB)
+
+        org.junit.Assert.assertSame(coreBefore, KindeClient.getInstance(context))
+    }
+}

--- a/sdk/src/test/kotlin/au/kinde/sdk/KindeSDKFacadeTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/KindeSDKFacadeTest.kt
@@ -92,6 +92,26 @@ class KindeSDKFacadeTest {
     }
 
     @Test
+    fun `listener shared by two facades survives destruction of the first`() {
+        // Common pattern: one SDKListener implemented by the Application or a
+        // shared auth manager, passed to every activity's KindeSDK.
+        val shared = RecordingListener()
+        val (controllerA, _) = buildSdk(shared)
+        buildSdk(shared)
+        val afterConstruction = shared.logoutCount
+
+        // With both facades alive, a core event is delivered exactly once.
+        KindeClient.getInstance(context).onEndSessionResult(Activity.RESULT_OK, null)
+        assertEquals(afterConstruction + 1, shared.logoutCount)
+
+        // LoginActivity-style teardown: A is destroyed after B attached the same
+        // listener. B must keep receiving events.
+        controllerA.destroy()
+        KindeClient.getInstance(context).onEndSessionResult(Activity.RESULT_OK, null)
+        assertEquals(afterConstruction + 2, shared.logoutCount)
+    }
+
+    @Test
     fun `core state survives activity recreation`() {
         val listenerA = RecordingListener()
         val (controllerA, _) = buildSdk(listenerA)

--- a/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
@@ -1,0 +1,65 @@
+package au.kinde.sdk
+
+import android.content.Context
+import android.os.Bundle
+import android.os.Looper
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Listener that records every callback so tests can assert on what reached it.
+ * onException is recorded but never asserted against zero: the client's init
+ * fires an async JWKS fetch at an unroutable test domain, which legitimately
+ * reports a failure.
+ */
+class RecordingListener : SDKListener {
+    val tokens = mutableListOf<String>()
+    var logoutCount = 0
+    val exceptions = mutableListOf<Exception>()
+
+    override fun onNewToken(token: String) {
+        tokens.add(token)
+    }
+
+    override fun onLogout() {
+        logoutCount++
+    }
+
+    override fun onException(exception: Exception) {
+        exceptions.add(exception)
+    }
+}
+
+/** The .invalid TLD is guaranteed unresolvable, so init's keys fetch fails harmlessly offline. */
+const val TEST_DOMAIN = "unit-test.kinde.invalid"
+const val TEST_CLIENT_ID = "test_client_id"
+
+/** Injects the manifest meta-data KindeClient's constructor requires. */
+fun installKindeMetaData(
+    context: Context,
+    domain: String? = TEST_DOMAIN,
+    clientId: String? = TEST_CLIENT_ID
+) {
+    val bundle = Bundle().apply {
+        domain?.let { putString("au.kinde.domain", it) }
+        clientId?.let { putString("au.kinde.clientId", it) }
+    }
+    shadowOf(context.packageManager)
+        .getInternalMutablePackageInfo(context.packageName)
+        .applicationInfo!!
+        .metaData = bundle
+}
+
+/**
+ * Runs main-looper tasks and polls until [condition] is true or [timeoutMs]
+ * elapses. Needed for flows that hop background thread -> main handler
+ * (e.g. logout).
+ */
+fun awaitCondition(timeoutMs: Long = 5_000, condition: () -> Boolean): Boolean {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+        shadowOf(Looper.getMainLooper()).idle()
+        if (condition()) return true
+        Thread.sleep(20)
+    }
+    return condition()
+}

--- a/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
@@ -40,8 +40,8 @@ fun installKindeMetaData(
     clientId: String? = TEST_CLIENT_ID
 ) {
     val bundle = Bundle().apply {
-        domain?.let { putString("au.kinde.domain", it) }
-        clientId?.let { putString("au.kinde.clientId", it) }
+        domain?.let { putString(KindeClient.DOMAIN_KEY, it) }
+        clientId?.let { putString(KindeClient.CLIENT_ID_KEY, it) }
     }
     shadowOf(context.packageManager)
         .getInternalMutablePackageInfo(context.packageName)

--- a/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/TestSupport.kt
@@ -3,25 +3,31 @@ package au.kinde.sdk
 import android.content.Context
 import android.os.Bundle
 import android.os.Looper
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import org.robolectric.Shadows.shadowOf
 
 /**
  * Listener that records every callback so tests can assert on what reached it.
- * onException is recorded but never asserted against zero: the client's init
- * fires an async JWKS fetch at an unroutable test domain, which legitimately
- * reports a failure.
+ * Thread-safe: the client notifies from background threads while tests read
+ * from the test thread. onException is recorded but never asserted against
+ * zero: the client's init fires an async JWKS fetch at an unroutable test
+ * domain, which legitimately reports a failure.
  */
 class RecordingListener : SDKListener {
-    val tokens = mutableListOf<String>()
-    var logoutCount = 0
-    val exceptions = mutableListOf<Exception>()
+    val tokens = CopyOnWriteArrayList<String>()
+    val exceptions = CopyOnWriteArrayList<Exception>()
+    private val logouts = AtomicInteger(0)
+
+    val logoutCount: Int
+        get() = logouts.get()
 
     override fun onNewToken(token: String) {
         tokens.add(token)
     }
 
     override fun onLogout() {
-        logoutCount++
+        logouts.incrementAndGet()
     }
 
     override fun onException(exception: Exception) {

--- a/sdk/src/test/kotlin/au/kinde/sdk/store/StoreTest.kt
+++ b/sdk/src/test/kotlin/au/kinde/sdk/store/StoreTest.kt
@@ -1,0 +1,66 @@
+package au.kinde.sdk.store
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class StoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `state round-trips through encryption`() {
+        val store = Store(context, "domain-a.kinde.com")
+
+        store.saveState("""{"auth":"state"}""")
+
+        assertEquals("""{"auth":"state"}""", store.getState())
+    }
+
+    @Test
+    fun `clearState removes stored state`() {
+        val store = Store(context, "domain-a.kinde.com")
+        store.saveState("some-state")
+
+        store.clearState()
+
+        assertNull(store.getState())
+    }
+
+    @Test
+    fun `keys round-trip through encryption`() {
+        val store = Store(context, "domain-a.kinde.com")
+
+        store.saveKeys("""{"keys":[]}""")
+
+        assertEquals("""{"keys":[]}""", store.getKeys())
+    }
+
+    @Test
+    fun `stores for different domains are isolated`() {
+        val storeA = Store(context, "domain-a.kinde.com")
+        val storeB = Store(context, "domain-b.kinde.com")
+
+        storeA.saveState("state-for-a")
+
+        assertNull(storeB.getState())
+        assertEquals("state-for-a", storeA.getState())
+    }
+
+    @Test
+    fun `same domain shares one store`() {
+        val first = Store(context, "domain-a.kinde.com")
+        val second = Store(context, "domain-a.kinde.com")
+
+        first.saveState("shared-state")
+
+        assertEquals("shared-state", second.getState())
+    }
+}


### PR DESCRIPTION
# Explain your changes

KindeSDK was activity-scoped, so every activity recreation rebuilt the token state and refresh timer. This could cancel refreshes mid-session, serve stale in-memory tokens, and replay rotated refresh tokens, invalidating sessions.

This PR splits the SDK in two. A new application-scoped KindeClient singleton owns all token state, refresh scheduling, and API access (one state and one refresh loop per process, plus activity-free token access for interceptors/workers via KindeClient.getInstance(context)), while KindeSDK keeps its exact public API and becomes a thin per-activity facade owning only the browser plumbing for login/logout.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
